### PR TITLE
[fix][io] Fix acknowledgments not being sent when collapsePartitionedTopics=true in kafka-connect-adapter

### DIFF
--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -300,9 +300,18 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             partitionOffset.put(tp.partition(), e.getValue().offset());
         }
 
+        int ackRequestedCount = 0;
         for (Record<GenericObject> r : pendingFlushQueue) {
-            final String topic = sanitizeNameIfNeeded(r.getTopicName().orElse(topicName), sanitizeTopicName);
-            final int partition = r.getPartitionIndex().orElse(0);
+            final String topic;
+            final int partition;
+            if (shouldCollapsePartitionedTopic(r)) {
+                TopicName tn = TopicName.get(r.getTopicName().get());
+                partition = tn.getPartitionIndex();
+                topic = sanitizeNameIfNeeded(tn.getPartitionedTopicName(), sanitizeTopicName);
+            } else {
+                partition = r.getPartitionIndex().orElse(0);
+                topic = sanitizeNameIfNeeded(r.getTopicName().orElse(topicName), sanitizeTopicName);
+            }
 
             Long lastCommittedOffset = null;
             if (topicOffsets.containsKey(topic)) {
@@ -326,15 +335,26 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             }
 
             cb.accept(r);
+            ackRequestedCount++;
             pendingFlushQueue.remove(r);
             currentBatchSize.addAndGet(-1 * r.getMessage().get().size());
             if (r == lastNotFlushed) {
                 break;
             }
         }
+        if (log.isDebugEnabled()) {
+            log.debug("ackRequestedCount: {}, committedOffsets: {}", ackRequestedCount, committedOffsets);
+        }
     }
 
-    private long getMessageOffset(Record<GenericObject> sourceRecord) {
+    private boolean shouldCollapsePartitionedTopic(Record<GenericObject> r) {
+        return collapsePartitionedTopics
+                && r.getTopicName().isPresent()
+                && TopicName.get(r.getTopicName().get()).isPartitioned();
+    }
+
+    @VisibleForTesting
+    long getMessageOffset(Record<GenericObject> sourceRecord) {
 
         if (sourceRecord.getMessage().isPresent()) {
             // Use index added by org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor if present.
@@ -440,9 +460,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         final int partition;
         final String topic;
 
-        if (collapsePartitionedTopics
-                && sourceRecord.getTopicName().isPresent()
-                && TopicName.get(sourceRecord.getTopicName().get()).isPartitioned()) {
+        if (shouldCollapsePartitionedTopic(sourceRecord)) {
             TopicName tn = TopicName.get(sourceRecord.getTopicName().get());
             partition = tn.getPartitionIndex();
             topic = sanitizeNameIfNeeded(tn.getPartitionedTopicName(), sanitizeTopicName);

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -101,7 +101,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     private int maxBatchBitsForOffset = 12;
     private boolean useIndexAsOffset = true;
 
-    private TopicPartitionResolver topicPartitionResolver;
+    TopicPartitionResolver topicPartitionResolver;
 
     @Override
     public void write(Record<GenericObject> sourceRecord) {
@@ -391,7 +391,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         private final int partition;
     }
 
-    private static class TopicPartitionResolver {
+    static class TopicPartitionResolver {
         private final String topicName;
         private final boolean sanitizeTopicName;
         private final boolean collapsePartitionedTopics;
@@ -443,7 +443,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
         // Replace all non-letter, non-digit characters with underscore.
         // Append underscore in front of name if it does not begin with alphabet or underscore.
-        private String sanitizeNameIfNeeded(String name) {
+        String sanitizeNameIfNeeded(String name) {
             if (!sanitizeTopicName) {
                 return name;
             }

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -252,6 +252,10 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             ackUntil(lastNotFlushed, committedOffsets, Record::ack);
             log.info("Flush succeeded");
         } catch (Throwable t) {
+            if (committedOffsets == null) {
+                log.error("preCommit failed — retrying to preserve ordering", t);
+                return;
+            }
             log.error("error flushing pending records", t);
             ackUntil(lastNotFlushed, committedOffsets, Record::fail);
         } finally {

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -431,8 +431,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         private String desanitizeTopicName(String kafkaName) {
             if (sanitizeTopicName) {
                 String pulsarTopicName = desanitizedTopicCache.getIfPresent(kafkaName);
-                if (KafkaConnectSink.log.isDebugEnabled()) {
-                    KafkaConnectSink.log.debug("desanitizedTopicCache got: kafkaName: {}, pulsarTopicName: {}",
+                if (log.isDebugEnabled()) {
+                    log.debug("desanitizedTopicCache got: kafkaName: {}, pulsarTopicName: {}",
                             kafkaName, pulsarTopicName);
                 }
                 return pulsarTopicName != null ? pulsarTopicName : kafkaName;
@@ -460,7 +460,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
                     return sanitizedName;
                 });
             } catch (ExecutionException e) {
-                KafkaConnectSink.log.error("Failed to get sanitized topic name for {}", name, e);
+                log.error("Failed to get sanitized topic name for {}", name, e);
                 throw new IllegalStateException("Failed to get sanitized topic name for " + name, e);
             }
         }

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -98,16 +98,6 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     // Thi is a workaround for https://github.com/apache/pulsar/issues/19922
     private boolean collapsePartitionedTopics = false;
 
-    private final Cache<String, String> sanitizedTopicCache =
-            CacheBuilder.newBuilder().maximumSize(1000)
-                    .expireAfterAccess(30, TimeUnit.MINUTES).build();
-
-    // Can't really safely expire these entries.  If we do, we could end up with
-    // a sanitized topic name that used in e.g. resume() after a long pause but can't be
-    // // re-resolved into a form usable for Pulsar.
-    private final Cache<String, String> desanitizedTopicCache =
-            CacheBuilder.newBuilder().build();
-
     private int maxBatchBitsForOffset = 12;
     private boolean useIndexAsOffset = true;
 
@@ -204,9 +194,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         topicPartitionResolver = new TopicPartitionResolver(
                 topicName,
                 sanitizeTopicName,
-                collapsePartitionedTopics,
-                sanitizedTopicCache,
-                desanitizedTopicCache);
+                collapsePartitionedTopics);
 
         taskContext =
                 new PulsarKafkaSinkTaskContext(configs.get(0), ctx, task::open,
@@ -407,19 +395,22 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         private final String topicName;
         private final boolean sanitizeTopicName;
         private final boolean collapsePartitionedTopics;
-        private final Cache<String, String> sanitizedTopicCache;
-        private final Cache<String, String> desanitizedTopicCache;
+        private final Cache<String, String> sanitizedTopicCache =
+                CacheBuilder.newBuilder().maximumSize(1000)
+                        .expireAfterAccess(30, TimeUnit.MINUTES).build();
+
+        // Can't really safely expire these entries.  If we do, we could end up with
+        // a sanitized topic name that used in e.g. resume() after a long pause but can't be
+        // // re-resolved into a form usable for Pulsar.
+        private final Cache<String, String> desanitizedTopicCache =
+                CacheBuilder.newBuilder().build();
 
         private TopicPartitionResolver(String topicName,
                                        boolean sanitizeTopicName,
-                                       boolean collapsePartitionedTopics,
-                                       Cache<String, String> sanitizedTopicCache,
-                                       Cache<String, String> desanitizedTopicCache) {
+                                       boolean collapsePartitionedTopics) {
             this.topicName = topicName;
             this.sanitizeTopicName = sanitizeTopicName;
             this.collapsePartitionedTopics = collapsePartitionedTopics;
-            this.sanitizedTopicCache = sanitizedTopicCache;
-            this.desanitizedTopicCache = desanitizedTopicCache;
         }
 
         private ResolvedTopicPartition resolve(Record<GenericObject> sourceRecord) {

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -111,6 +111,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     private int maxBatchBitsForOffset = 12;
     private boolean useIndexAsOffset = true;
 
+    private TopicPartitionResolver topicPartitionResolver;
+
     @Override
     public void write(Record<GenericObject> sourceRecord) {
         if (log.isDebugEnabled()) {
@@ -198,19 +200,17 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             x.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, kafkaSinkConfig.getOffsetStorageTopic());
         });
         task = (SinkTask) taskClass.getConstructor().newInstance();
+
+        topicPartitionResolver = new TopicPartitionResolver(
+                topicName,
+                sanitizeTopicName,
+                collapsePartitionedTopics,
+                sanitizedTopicCache,
+                desanitizedTopicCache);
+
         taskContext =
-                new PulsarKafkaSinkTaskContext(configs.get(0), ctx, task::open, kafkaName -> {
-                    if (sanitizeTopicName) {
-                        String pulsarTopicName = desanitizedTopicCache.getIfPresent(kafkaName);
-                        if (log.isDebugEnabled()) {
-                            log.debug("desanitizedTopicCache got: kafkaName: {}, pulsarTopicName: {}",
-                                    kafkaName, pulsarTopicName);
-                        }
-                        return pulsarTopicName != null ? pulsarTopicName : kafkaName;
-                    } else {
-                        return kafkaName;
-                    }
-                });
+                new PulsarKafkaSinkTaskContext(configs.get(0), ctx, task::open,
+                        topicPartitionResolver::desanitizeTopicName);
         task.initialize(taskContext);
         task.start(configs.get(0));
 
@@ -302,20 +302,11 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
         int ackRequestedCount = 0;
         for (Record<GenericObject> r : pendingFlushQueue) {
-            final String topic;
-            final int partition;
-            if (shouldCollapsePartitionedTopic(r)) {
-                TopicName tn = TopicName.get(r.getTopicName().get());
-                partition = tn.getPartitionIndex();
-                topic = sanitizeNameIfNeeded(tn.getPartitionedTopicName(), sanitizeTopicName);
-            } else {
-                partition = r.getPartitionIndex().orElse(0);
-                topic = sanitizeNameIfNeeded(r.getTopicName().orElse(topicName), sanitizeTopicName);
-            }
+            ResolvedTopicPartition resolved = topicPartitionResolver.resolve(r);
 
             Long lastCommittedOffset = null;
-            if (topicOffsets.containsKey(topic)) {
-                lastCommittedOffset = topicOffsets.get(topic).get(partition);
+            if (topicOffsets.containsKey(resolved.getTopic())) {
+                lastCommittedOffset = topicOffsets.get(resolved.getTopic()).get(resolved.getPartition());
             }
 
             if (lastCommittedOffset == null) {
@@ -345,12 +336,6 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         if (log.isDebugEnabled()) {
             log.debug("ackRequestedCount: {}, committedOffsets: {}", ackRequestedCount, committedOffsets);
         }
-    }
-
-    private boolean shouldCollapsePartitionedTopic(Record<GenericObject> r) {
-        return collapsePartitionedTopics
-                && r.getTopicName().isPresent()
-                && TopicName.get(r.getTopicName().get()).isPartitioned();
     }
 
     @VisibleForTesting
@@ -411,6 +396,91 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         int batchIdx;
     }
 
+    @Getter
+    @AllArgsConstructor
+    static class ResolvedTopicPartition {
+        private final String topic;
+        private final int partition;
+    }
+
+    private static class TopicPartitionResolver {
+        private final String topicName;
+        private final boolean sanitizeTopicName;
+        private final boolean collapsePartitionedTopics;
+        private final Cache<String, String> sanitizedTopicCache;
+        private final Cache<String, String> desanitizedTopicCache;
+
+        private TopicPartitionResolver(String topicName,
+                                       boolean sanitizeTopicName,
+                                       boolean collapsePartitionedTopics,
+                                       Cache<String, String> sanitizedTopicCache,
+                                       Cache<String, String> desanitizedTopicCache) {
+            this.topicName = topicName;
+            this.sanitizeTopicName = sanitizeTopicName;
+            this.collapsePartitionedTopics = collapsePartitionedTopics;
+            this.sanitizedTopicCache = sanitizedTopicCache;
+            this.desanitizedTopicCache = desanitizedTopicCache;
+        }
+
+        private ResolvedTopicPartition resolve(Record<GenericObject> sourceRecord) {
+            final int partition;
+            final String topic;
+
+            if (shouldCollapsePartitionedTopic(sourceRecord)) {
+                TopicName tn = TopicName.get(sourceRecord.getTopicName().get());
+                partition = tn.getPartitionIndex();
+                topic = sanitizeNameIfNeeded(tn.getPartitionedTopicName());
+            } else {
+                partition = sourceRecord.getPartitionIndex().orElse(0);
+                topic = sanitizeNameIfNeeded(sourceRecord.getTopicName().orElse(topicName));
+            }
+            return new ResolvedTopicPartition(topic, partition);
+        }
+
+        private String desanitizeTopicName(String kafkaName) {
+            if (sanitizeTopicName) {
+                String pulsarTopicName = desanitizedTopicCache.getIfPresent(kafkaName);
+                if (KafkaConnectSink.log.isDebugEnabled()) {
+                    KafkaConnectSink.log.debug("desanitizedTopicCache got: kafkaName: {}, pulsarTopicName: {}",
+                            kafkaName, pulsarTopicName);
+                }
+                return pulsarTopicName != null ? pulsarTopicName : kafkaName;
+            } else {
+                return kafkaName;
+            }
+        }
+
+        // Replace all non-letter, non-digit characters with underscore.
+        // Append underscore in front of name if it does not begin with alphabet or underscore.
+        private String sanitizeNameIfNeeded(String name) {
+            if (!sanitizeTopicName) {
+                return name;
+            }
+
+            try {
+                return sanitizedTopicCache.get(name, () -> {
+                    String sanitizedName = name.replaceAll("[^a-zA-Z0-9_]", "_");
+                    if (sanitizedName.matches("^[^a-zA-Z_].*")) {
+                        sanitizedName = "_" + sanitizedName;
+                    }
+                    // do this once, sanitize() can be called on already sanitized name
+                    // so avoid replacing with (sanitizedName -> sanitizedName).
+                    desanitizedTopicCache.get(sanitizedName, () -> name);
+                    return sanitizedName;
+                });
+            } catch (ExecutionException e) {
+                KafkaConnectSink.log.error("Failed to get sanitized topic name for {}", name, e);
+                throw new IllegalStateException("Failed to get sanitized topic name for " + name, e);
+            }
+        }
+
+        private boolean shouldCollapsePartitionedTopic(Record<GenericObject> r) {
+            return collapsePartitionedTopics
+                    && r.getTopicName().isPresent()
+                    && TopicName.get(r.getTopicName().get()).isPartitioned();
+        }
+    }
+
     private static Method getMethodOfMessageId(MessageId messageId, String name) throws NoSuchMethodException {
         Class<?> clazz = messageId.getClass();
         NoSuchMethodException firstException = null;
@@ -457,17 +527,11 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
     @SuppressWarnings("rawtypes")
     protected SinkRecord toSinkRecord(Record<GenericObject> sourceRecord) {
-        final int partition;
-        final String topic;
 
-        if (shouldCollapsePartitionedTopic(sourceRecord)) {
-            TopicName tn = TopicName.get(sourceRecord.getTopicName().get());
-            partition = tn.getPartitionIndex();
-            topic = sanitizeNameIfNeeded(tn.getPartitionedTopicName(), sanitizeTopicName);
-        } else {
-            partition = sourceRecord.getPartitionIndex().orElse(0);
-            topic = sanitizeNameIfNeeded(sourceRecord.getTopicName().orElse(topicName), sanitizeTopicName);
-        }
+        ResolvedTopicPartition resolved = topicPartitionResolver.resolve(sourceRecord);
+        final int partition = resolved.getPartition();
+        final String topic = resolved.getTopic();
+
         final Object key;
         final Object value;
         final Schema keySchema;
@@ -540,31 +604,6 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
     @VisibleForTesting
     protected long currentOffset(String topic, int partition) {
-        return taskContext.currentOffset(sanitizeNameIfNeeded(topic, sanitizeTopicName), partition);
+        return taskContext.currentOffset(topicPartitionResolver.sanitizeNameIfNeeded(topic), partition);
     }
-
-    // Replace all non-letter, non-digit characters with underscore.
-    // Append underscore in front of name if it does not begin with alphabet or underscore.
-    protected String sanitizeNameIfNeeded(String name, boolean sanitize) {
-        if (!sanitize) {
-            return name;
-        }
-
-        try {
-            return sanitizedTopicCache.get(name, () -> {
-                String sanitizedName = name.replaceAll("[^a-zA-Z0-9_]", "_");
-                if (sanitizedName.matches("^[^a-zA-Z_].*")) {
-                    sanitizedName = "_" + sanitizedName;
-                }
-                // do this once, sanitize() can be called on already sanitized name
-                // so avoid replacing with (sanitizedName -> sanitizedName).
-                desanitizedTopicCache.get(sanitizedName, () -> name);
-                return sanitizedName;
-            });
-        } catch (ExecutionException e) {
-            log.error("Failed to get sanitized topic name for {}", name, e);
-            throw new IllegalStateException("Failed to get sanitized topic name for " + name, e);
-        }
-    }
-
 }

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -101,7 +101,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     private int maxBatchBitsForOffset = 12;
     private boolean useIndexAsOffset = true;
 
-    TopicPartitionResolver topicPartitionResolver;
+    private TopicPartitionResolver topicPartitionResolver;
 
     @Override
     public void write(Record<GenericObject> sourceRecord) {
@@ -380,6 +380,11 @@ public class KafkaConnectSink implements Sink<GenericObject> {
                 .orElse(-1L);
     }
 
+    @VisibleForTesting
+    TopicPartitionResolver getTopicPartitionResolver() {
+        return topicPartitionResolver;
+    }
+
     @Getter
     @AllArgsConstructor
     static class BatchMessageSequenceRef {
@@ -404,8 +409,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
                         .expireAfterAccess(30, TimeUnit.MINUTES).build();
 
         // Can't really safely expire these entries.  If we do, we could end up with
-        // a sanitized topic name that used in e.g. resume() after a long pause but can't be
-        // // re-resolved into a form usable for Pulsar.
+        // a sanitized topic name that is used in e.g. resume() after a long pause but can't be
+        // re-resolved into a form usable for Pulsar.
         private final Cache<String, String> desanitizedTopicCache =
                 CacheBuilder.newBuilder().build();
 

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -344,7 +344,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
         assertEquals(status.get(), 1);
 
-        final TopicPartition tp = new TopicPartition(sink.topicPartitionResolver
+        final TopicPartition tp = new TopicPartition(sink.getTopicPartitionResolver()
                 .sanitizeNameIfNeeded(pulsarTopicName), 0);
         assertNotEquals(FunctionCommon.getSequenceId(msgId), 0);
         assertEquals(sink.currentOffset(tp.topic(), tp.partition()), FunctionCommon.getSequenceId(msgId));

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -344,7 +344,8 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
         assertEquals(status.get(), 1);
 
-        final TopicPartition tp = new TopicPartition(sink.sanitizeNameIfNeeded(pulsarTopicName, true), 0);
+        final TopicPartition tp = new TopicPartition(sink.topicPartitionResolver
+                .sanitizeNameIfNeeded(pulsarTopicName), 0);
         assertNotEquals(FunctionCommon.getSequenceId(msgId), 0);
         assertEquals(sink.currentOffset(tp.topic(), tp.partition()), FunctionCommon.getSequenceId(msgId));
 

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -1574,7 +1574,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
         assertNull(ref);
 
         ref = KafkaConnectSink.getMessageSequenceRefForBatchMessage(
-                        new TopicMessageIdImpl("topic-0", new MessageIdImpl(ledgerId, entryId, 0))
+                new TopicMessageIdImpl("topic-0", new MessageIdImpl(ledgerId, entryId, 0))
         );
         assertNull(ref);
 
@@ -1648,7 +1648,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
         props.put("collapsePartitionedTopics", Boolean.toString(isEnabled));
 
         KafkaConnectSink sink = new KafkaConnectSink();
-            sink.open(props, context);
+        sink.open(props, context);
 
         AvroSchema<PulsarSchemaToKafkaSchemaTest.StructWithAnnotations> pulsarAvroSchema =
                 AvroSchema.of(PulsarSchemaToKafkaSchemaTest.StructWithAnnotations.class);
@@ -1678,6 +1678,67 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
         Assert.assertEquals(sinkRecord.topic(), expectedKafkaTopic);
         Assert.assertEquals(sinkRecord.kafkaPartition(), expectedPartition);
+
+        sink.close();
+    }
+
+    @Test
+    public void testAckUntilWithCollapsePartitionedTopics() throws Exception {
+        testAckUntil(true,
+                "persistent://a/b/fake-topic-partition-0",
+                "persistent://a/b/fake-topic",
+                0);
+    }
+
+    @Test
+    public void testAckUntilWithoutCollapsePartitionedTopics() throws Exception {
+        // Note: Without collapsePartitionedTopics expectedPartition in the committedOffsets will always be 0
+        testAckUntil(false,
+                "persistent://a/b/fake-topic-partition-1",
+                "persistent://a/b/fake-topic-partition-1",
+                0);
+    }
+
+    private void testAckUntil(boolean collapseEnabled,
+                              String pulsarTopic,
+                              String expectedKafkaTopic,
+                              int expectedPartition) throws Exception {
+        // Setup sink with given collapseEnabled value
+        props.put("kafkaConnectorSinkClass", SchemaedFileStreamSinkConnector.class.getCanonicalName());
+        props.put("collapsePartitionedTopics", Boolean.toString(collapseEnabled));
+        KafkaConnectSink sink = new KafkaConnectSink();
+        sink.open(props, context);
+
+        // Create pulsar record with given pulsarTopic and expectedPartition
+        Message msg = mock(MessageImpl.class);
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 1, expectedPartition));
+        when(msg.getValue()).thenReturn(null);
+
+        AtomicInteger ackCount = new AtomicInteger(0);
+
+        Record<GenericObject> record = PulsarRecord.<GenericObject>builder()
+                .topicName(pulsarTopic)
+                .message(msg)
+                .ackFunction(ackCount::incrementAndGet)
+                .failFunction(() -> {})
+                .build();
+
+        // Add the pulsar record to pendingFlushQueue
+        sink.pendingFlushQueue.add(record);
+
+        // Build committedOffsets with the given expectedKafkaTopic and expectedPartition
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets = new HashMap<>();
+        committedOffsets.put(
+                new TopicPartition(expectedKafkaTopic, expectedPartition),
+                new OffsetAndMetadata(sink.getMessageOffset(record))
+        );
+
+        // Trigger actUntil manually
+        sink.ackUntil(record, committedOffsets, Record::ack);
+
+        // Assert that the ackFunction runnable of the record is called and pendingFlushQueue is empty
+        Assert.assertEquals(ackCount.get(), 1);
+        Assert.assertTrue(sink.pendingFlushQueue.isEmpty());
 
         sink.close();
     }

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -1734,7 +1734,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
                 new OffsetAndMetadata(sink.getMessageOffset(record))
         );
 
-        // Trigger actUntil manually
+        // Trigger ackUntil manually
         sink.ackUntil(record, committedOffsets, Record::ack);
 
         // Assert that the ackFunction runnable of the record is called and pendingFlushQueue is empty


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes [25450](https://github.com/apache/pulsar/issues/25450)

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Fix acknowledgments not being sent when the `collapsePartitionedTopics=true` on kafka-connect-adapter. The topic name stored in [sinkrecord](https://github.com/apache/pulsar/blob/3d33e4874fefa2a570a1ef60e02d9e995c4dde27/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java#L443) and [currentOffsets](https://github.com/apache/pulsar/blob/3d33e4874fefa2a570a1ef60e02d9e995c4dde27/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java#L500) is different from the topic name stored in the pulsar record. 

The topic name used in SinkRecord / currentOffsets is collapsed (base topic name) and the topic name in the original Pulsar Record remains non-collapsed (includes -partition-X)

As a result, during `ackUntil()`
- Topic lookup in committedOffsets fails
- [lastCommittedOffset](https://github.com/apache/pulsar/blob/3d33e4874fefa2a570a1ef60e02d9e995c4dde27/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java#L312) will always be `null` because of topic name mismatch.
- Records are never acknowledged

### Modifications

<!-- Describe the modifications you've done. -->
Updated `ackUntil()` to derive topic and partition from the source Record using the same logic as `toSinkRecord()` (i.e., respecting `collapsePartitionedTopics`)
Added a debug log and `ackRequestedCount` for better logging clarity.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *org.apache.pulsar.io.kafka.connect.KafkaConnectSinkTest#testAckUntilWithCollapsePartitionedTopics*
  - *org.apache.pulsar.io.kafka.connect.KafkaConnectSinkTest#testAckUntilWithoutCollapsePartitionedTopics*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/cognitree/pulsar-connectors/pull/1
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
