### PR TITLE
[improve][io] JDBC sink: replace synchronized queue with LinkedBlockingDeque for proper back-pressure

### DIFF
--- a/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
+++ b/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
@@ -24,6 +24,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -76,7 +78,7 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
     protected JdbcUtils.TableDefinition tableDefinition;
 
     // for flush
-    private Deque<Record<T>> incomingList;
+    private LinkedBlockingDeque<Record<T>> incomingList;
     private AtomicBoolean isFlushing;
     private int batchSize;
     private int maxQueueSize;
@@ -84,7 +86,6 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
     private ScheduledFuture<?> scheduledFlushTask;
     private SinkContext sinkContext;
     private Properties connectionProperties;
-    private volatile boolean queueFullLogged = false;
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
 
     @Override
@@ -127,7 +128,11 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
         }
         // maxQueueSize < 0 (i.e. -1) means unbounded (legacy behavior)
         log.info("JDBC sink queue capacity: {}", maxQueueSize > 0 ? maxQueueSize : "unbounded");
-        incomingList = new LinkedList<>();
+        if (maxQueueSize > 0) {
+            incomingList = new LinkedBlockingDeque<>(maxQueueSize);
+        } else {
+            incomingList = new LinkedBlockingDeque<>();
+        }
         isFlushing = new AtomicBoolean(false);
 
         flushExecutor = Executors.newScheduledThreadPool(1);
@@ -172,6 +177,10 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
     @Override
     public void close() throws Exception {
         state.set(State.CLOSED);
+        // Fail any records still in the queue
+        List<Record<T>> remaining = new ArrayList<>();
+        incomingList.drainTo(remaining);
+        remaining.forEach(Record::fail);
         if (scheduledFlushTask != null) {
             scheduledFlushTask.cancel(false);
             scheduledFlushTask = null;
@@ -211,31 +220,30 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
             record.fail();
             return;
         }
-        int number = 0;
-        boolean shouldFail = false;
-        boolean shouldLogQueueFull = false;
-        int queueSizeSnapshot = 0;
-        synchronized (incomingList) {
-            if (maxQueueSize > 0 && incomingList.size() >= maxQueueSize) {
-                if (!queueFullLogged) {
-                    queueFullLogged = true;
-                    shouldLogQueueFull = true;
-                    queueSizeSnapshot = incomingList.size();
-                }
-                shouldFail = true;
-            } else {
-                incomingList.add(record);
-                number = incomingList.size();
-            }
+
+        // Block until space is available or timeout expires.
+        // Blocking the Pulsar IO thread IS the back-pressure: it stops
+        // message consumption for this sink's subscription.
+        boolean accepted;
+        try {
+            accepted = incomingList.offer(record, 1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            record.fail();
+            return;
         }
-        if (shouldFail) {
-            if (shouldLogQueueFull) {
-                log.warn("Internal queue is full ({} >= {}), failing records to apply back-pressure",
-                        queueSizeSnapshot, maxQueueSize);
+
+        if (!accepted) {
+            if (state.get() != State.OPEN) {
+                log.warn("Sink became {} while waiting for queue space, failing record", state.get());
+            } else {
+                log.warn("Queue still full after timeout (capacity: {}), failing record", maxQueueSize);
             }
             record.fail();
             return;
         }
+
+        int number = incomingList.size();
         if (batchSize > 0 && number >= batchSize) {
             if (log.isDebugEnabled()) {
                 log.debug("flushing by batches, hit batch size {}", batchSize);
@@ -287,108 +295,99 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
         }
         if (!isFlushing.compareAndSet(false, true)) {
             if (log.isDebugEnabled()) {
-                synchronized (incomingList) {
-                    log.debug("Already in flushing state, will not flush, queue size: {}", incomingList.size());
-                }
+                log.debug("Already in flushing state, will not flush, queue size: {}", incomingList.size());
             }
             return;
         }
-        boolean needAnotherRound;
-        final Deque<Record<T>> swapList = new LinkedList<>();
 
-        synchronized (incomingList) {
-            if (incomingList.isEmpty()) {
-                isFlushing.set(false);
-                return;
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("Starting flush, queue size: {}", incomingList.size());
-            }
-            final int actualBatchSize = batchSize > 0 ? Math.min(incomingList.size(), batchSize) :
-                    incomingList.size();
-
-            for (int i = 0; i < actualBatchSize; i++) {
-                swapList.add(incomingList.removeFirst());
-            }
-            needAnotherRound = batchSize > 0 && !incomingList.isEmpty() && incomingList.size() >= batchSize;
-        }
-            long start = System.nanoTime();
-
-            int count = 0;
-            try {
-                ensureConnection();
-
-                PreparedStatement currentBatch = null;
-                final List<Mutation> mutations = swapList
-                        .stream()
-                        .map(this::createMutation)
-                        .collect(Collectors.toList());
-                // bind each record value
-                PreparedStatement statement;
-                for (Mutation mutation : mutations) {
-                    switch (mutation.getType()) {
-                        case DELETE:
-                            statement = deleteStatement;
-                            break;
-                        case UPDATE:
-                            statement = updateStatement;
-                            break;
-                        case INSERT:
-                            statement = insertStatement;
-                            break;
-                        case UPSERT:
-                            statement = upsertStatement;
-                            break;
-                        default:
-                            String msg = String.format(
-                                    "Unsupported action %s, can be one of %s, or not set which indicate %s",
-                                    mutation.getType(), Arrays.toString(MutationType.values()), MutationType.INSERT);
-                            throw new IllegalArgumentException(msg);
-                    }
-                    bindValue(statement, mutation);
-                    count += 1;
-                    if (jdbcSinkConfig.isUseJdbcBatch()) {
-                        if (currentBatch != null && statement != currentBatch) {
-                            internalFlushBatch(swapList, currentBatch, count, start);
-                            start = System.nanoTime();
-                        }
-                        statement.addBatch();
-                        currentBatch = statement;
-                    } else {
-                        statement.execute();
-                        if (!jdbcSinkConfig.isUseTransactions()) {
-                            swapList.removeFirst().ack();
-                        }
-                    }
-                }
-
-                if (jdbcSinkConfig.isUseJdbcBatch()) {
-                    internalFlushBatch(swapList, currentBatch, count, start);
-                } else {
-                    internalFlush(swapList);
-                }
-                queueFullLogged = false;
-            } catch (Exception e) {
-                log.error("Got exception {} after {} ms, failing {} messages",
-                        e.getMessage(),
-                        (System.nanoTime() - start) / 1000 / 1000,
-                        swapList.size(),
-                        e);
-                swapList.forEach(Record::fail);
+        try {
+            boolean continueLoop = true;
+            while (continueLoop) {
+                continueLoop = false;
+                final Deque<Record<T>> swapList = new LinkedList<>();
                 try {
-                    if (jdbcSinkConfig.isUseTransactions()) {
-                        connection.rollback();
+                    int drainSize = batchSize > 0 ? batchSize : Integer.MAX_VALUE;
+                    incomingList.drainTo(swapList, drainSize);
+                    if (swapList.isEmpty()) {
+                        return;
                     }
-                } catch (Exception ex) {
-                    log.error("Failed to rollback transaction", ex);
-                }
-                fatal(e);
-            }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Starting flush, drained {} records, queue remaining: {}",
+                                swapList.size(), incomingList.size());
+                    }
 
-            isFlushing.set(false);
-            if (needAnotherRound) {
-                flush();
+                    long start = System.nanoTime();
+                    int count = 0;
+
+                    ensureConnection();
+
+                    PreparedStatement currentBatch = null;
+                    final List<Mutation> mutations = swapList
+                            .stream()
+                            .map(this::createMutation)
+                            .collect(Collectors.toList());
+                    // bind each record value
+                    PreparedStatement statement;
+                    for (Mutation mutation : mutations) {
+                        switch (mutation.getType()) {
+                            case DELETE:
+                                statement = deleteStatement;
+                                break;
+                            case UPDATE:
+                                statement = updateStatement;
+                                break;
+                            case INSERT:
+                                statement = insertStatement;
+                                break;
+                            case UPSERT:
+                                statement = upsertStatement;
+                                break;
+                            default:
+                                String msg = String.format(
+                                        "Unsupported action %s, can be one of %s, or not set which indicate %s",
+                                        mutation.getType(), Arrays.toString(MutationType.values()), MutationType.INSERT);
+                                throw new IllegalArgumentException(msg);
+                        }
+                        bindValue(statement, mutation);
+                        count += 1;
+                        if (jdbcSinkConfig.isUseJdbcBatch()) {
+                            if (currentBatch != null && statement != currentBatch) {
+                                internalFlushBatch(swapList, currentBatch, count, start);
+                                start = System.nanoTime();
+                            }
+                            statement.addBatch();
+                            currentBatch = statement;
+                        } else {
+                            statement.execute();
+                            if (!jdbcSinkConfig.isUseTransactions()) {
+                                swapList.removeFirst().ack();
+                            }
+                        }
+                    }
+
+                    if (jdbcSinkConfig.isUseJdbcBatch()) {
+                        internalFlushBatch(swapList, currentBatch, count, start);
+                    } else {
+                        internalFlush(swapList);
+                    }
+                    continueLoop = batchSize > 0 && incomingList.size() >= batchSize;
+                } catch (Exception e) {
+                    log.error("Got exception {} failing {} messages",
+                            e.getMessage(), swapList.size(), e);
+                    swapList.forEach(Record::fail);
+                    try {
+                        if (jdbcSinkConfig.isUseTransactions()) {
+                            connection.rollback();
+                        }
+                    } catch (Exception ex) {
+                        log.error("Failed to rollback transaction", ex);
+                    }
+                    fatal(e);
+                }
             }
+        } finally {
+            isFlushing.set(false);
+        }
     }
 
     private void ensureConnection() throws Exception {


### PR DESCRIPTION
## Motivation

Follow-up to #9. The `record.fail()` back-pressure introduced in #9 causes a **nack/redeliver storm** under sustained load — the consumer delivers messages, the sink immediately fails them, they get redelivered, repeating endlessly. This wastes CP time.

## Modifications

Replace `LinkedList` + `synchronized` with `LinkedBlockingDeque`:

- **`write()`**: `offer(record, 1, TimeUnit.SECONDS)` blocks the Pulsar IO thread when queue is full — this IS the back-pressure (stops consumption). At most 1 nack/second on timeout vs. thousands/second before.
- **`flush()`**: `drainTo(swapList, batchSize)` — non-blocking atomic drain, no synchronized blocks. Automatically wakes blocked `offer()` calls by making space.
- **Recursive → iterative**: `flush()` uses a `while` loop instead of recursive self-calls.
- **`isFlushing` in `finally`**: prevents stuck flag after exceptions.
- **`close()` drains queue**: fails remaining records for clean shutdown.

Follows the pattern already used by Aerospike (`LinkedBlockingDeque`), HDFS, Kinesis, and DynamoDB (`LinkedBlockingQueue`) connectors in this repo.

## Verifying this change

- Existing tests pass (queue semantics preserved)
- `testBoundedQueueBackPressure` may need timeout adjustment (6th write now blocks 1s instead of failing instantly)

Fixes #16