### PR TITLE
[fix][build] Fix the Jetty 9 bom override solution for Alluxio plugin

### DIFF
--- a/alluxio/build.gradle.kts
+++ b/alluxio/build.gradle.kts
@@ -34,7 +34,7 @@ pulsarConnectorsDependencies {
 
 dependencies {
     // Alluxio-compatible BOMs — these override the shared platform versions.
-    implementation(enforcedPlatform(libs.jetty9.bom))
+    implementation(enforcedPlatform(libs.jetty9.bom.override))
     implementation(enforcedPlatform("io.netty:netty-bom:4.1.100.Final"))
     implementation(enforcedPlatform("io.grpc:grpc-bom:1.37.0"))
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -258,7 +258,9 @@ curator-recipes = { module = "org.apache.curator:curator-recipes", version.ref =
 conscrypt-openjdk-uber = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref = "conscrypt" }
 # Jetty
 jetty-bom = { module = "org.eclipse.jetty:jetty-bom", version.ref = "jetty" }
-jetty9-bom = { module = "org.eclipse.jetty:jetty-bom", version.ref = "jetty9" }
+# Override for alluxio: alluxio requires the older jetty 9.x. Aliases ending in
+# `-override` are NOT added to the shared `pulsar-connectors-dependencies` platform
+jetty9-bom-override = { module = "org.eclipse.jetty:jetty-bom", version.ref = "jetty9" }
 jetty-server = { module = "org.eclipse.jetty:jetty-server" }
 jetty-util = { module = "org.eclipse.jetty:jetty-util" }
 jetty-alpn-conscrypt-server = { module = "org.eclipse.jetty:jetty-alpn-conscrypt-server" }

--- a/pulsar-connectors-dependencies/build.gradle.kts
+++ b/pulsar-connectors-dependencies/build.gradle.kts
@@ -36,6 +36,11 @@ dependencies {
     // the version we specify, regardless of what version a transitive dependency requests.
     // BOM entries (detected by alias name) are imported as platforms rather than constraints.
     catalog.libraryAliases.forEach { alias ->
+        // Skip aliases that are subproject-specific overrides (e.g. jetty9-bom-override).
+        // These pin the same Maven coordinates to a different version than the shared
+        // platform — including them here would declare two versions of the same module
+        // and break consumers (e.g. alluxio uses jetty 9.x while everything else uses 12.x).
+        if (alias.endsWith(".override")) return@forEach
         catalog.findLibrary(alias).ifPresent { provider ->
             val dep = provider.get()
             if (alias.endsWith(".bom")) {


### PR DESCRIPTION
### Motivation

The current pulsar-connector-dependencies will add all aliases for all dependencies in the libs.versions.toml. 
There was one BOM `jetty9-bom` which was conflicting with `jetty-bom`. 

### Modifications

This PR adds changes where `jetty9-bom` alias is renamed to `jetty9-bom-override`. In pulsar-connector-dependencies, all aliases ending with `.override` will be skipped.