### PR TITLE
[improve][build] Sync version catalog with apache/pulsar master

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,14 +29,14 @@ bookkeeper = "4.17.3"
 zookeeper = "3.9.5"
 netty = "4.1.132.Final"
 netty-iouring = "0.0.26.Final"
-jetty = "12.1.5"
+jetty = "12.1.8"
 jetty9 = "9.4.58.v20250814"
 jersey = "2.42"
-jackson = "2.18.6"
+jackson = "2.21.2"
 protobuf = "3.25.5"
 grpc = "1.75.0"
 slf4j = "2.0.17"
-log4j2 = "2.25.3"
+log4j2 = "2.25.4"
 lombok = "1.18.42"
 # OpenTelemetry
 opentelemetry = "1.56.0"
@@ -57,11 +57,10 @@ commons-logging = "1.3.5"
 commons-beanutils = "1.11.0"
 commons-configuration2 = "2.12.0"
 # BouncyCastle
-bouncycastle-bcprov = "1.78.1"
-bouncycastle-bcpkix = "1.81"
-bouncycastle-bcutil = "1.81"
-bouncycastle-bcprov-ext = "1.78.1"
-bouncycastle-bcpkix-fips = "2.0.10"
+bouncycastle-bcprov = "1.84"
+bouncycastle-bcpkix = "1.84"
+bouncycastle-bcutil = "1.84"
+bouncycastle-bcpkix-fips = "2.0.11"
 bouncycastle-bc-fips = "2.0.1"
 # Serialization
 avro = "1.12.0"
@@ -70,7 +69,7 @@ snakeyaml = "2.0"
 # Vert.x
 vertx = "4.5.24"
 # Networking / HTTP
-asynchttpclient = "2.12.4"
+asynchttpclient = "2.14.5"
 conscrypt = "2.5.2"
 okhttp3 = "5.3.1"
 okio = "3.16.3"
@@ -305,10 +304,9 @@ opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semco
 opentelemetry-gcp-resources = { module = "io.opentelemetry.contrib:opentelemetry-gcp-resources", version.ref = "opentelemetry-gcp-resources" }
 # BouncyCastle
 bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle-bcpkix" }
-bcprov-ext-jdk18on = { module = "org.bouncycastle:bcprov-ext-jdk18on", version.ref = "bouncycastle-bcprov-ext" }
 bcpkix-fips = { module = "org.bouncycastle:bcpkix-fips", version.ref = "bouncycastle-bcpkix-fips" }
 bc-fips = { module = "org.bouncycastle:bc-fips", version.ref = "bouncycastle-bc-fips" }
-bcutil-fips = "org.bouncycastle:bcutil-fips:2.0.5"
+bcutil-fips = "org.bouncycastle:bcutil-fips:2.0.6"
 # RocksDB
 rocksdbjni = { module = "org.rocksdb:rocksdbjni", version.ref = "rocksdb" }
 # Error Prone


### PR DESCRIPTION
## Summary

Pull library version updates from [apache/pulsar's `gradle/libs.versions.toml`](https://github.com/apache/pulsar/blob/master/gradle/libs.versions.toml) into this repo's catalog so connectors build against the same baseline as the broker:

- `jetty` 12.1.5 → 12.1.8
- `jackson` 2.18.6 → 2.21.2
- `log4j2` 2.25.3 → 2.25.4
- `asynchttpclient` 2.12.4 → 2.14.5
- `bouncycastle` (`bcprov`/`bcpkix`/`bcutil`) → 1.84 — addresses CVE-2026-5588 and CVE-2026-0636
- `bcpkix-fips` 2.0.10 → 2.0.11
- `bcutil-fips` 2.0.5 → 2.0.6

Drops `bcprov-ext-jdk18on`: the BC team retired the `-ext` variant (last release 1.78.1), and pinning it alongside `bcprov` 1.84 would shadow the CVE-2026-0636 fix. No consumers in this repo. Matches apache/pulsar#25569.

Connector-specific entries (kafka, debezium, opensearch, hbase, aws-sdk2, etc.) and `jetty9` are intentionally left untouched since they don't exist or are pinned independently in upstream Pulsar.

## Test plan

- [ ] CI passes
- [ ] Local Gradle build resolves new versions cleanly