### PR TITLE
[fix][io] Fix delayed acknowledgment for offset 0 in Kafka Connect Adapter

### DIFF
--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
@@ -126,7 +126,7 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
     public Map<TopicPartition, OffsetAndMetadata> currentOffsets() {
         Map<TopicPartition, OffsetAndMetadata> snapshot = Maps.newHashMapWithExpectedSize(currentOffsets.size());
         currentOffsets.forEach((topicPartition, offset) -> {
-            if (offset > 0) {
+            if (offset >= 0) {
                 snapshot.put(topicPartition,
                         new OffsetAndMetadata(offset, Optional.empty(), null));
             }

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -1207,8 +1207,10 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
         // offset is 0 for the first written record
         assertEquals(sink.currentOffset(topicName, partition), 0);
-        // currentOffsets() should include the first record (offset 0) when processed by ackUntil
-        assertEquals(sink.taskContext.currentOffsets().size(), 1);
+        // current offsets map returned by the PulsarKafkaSinkTaskContext should contain the record with offset 0
+        assertEquals(
+                sink.taskContext.currentOffsets().get(new TopicPartition(topicName, partition)).offset(), 0
+        );
 
         entryId.set(1);
         sink.write(record);

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -1207,6 +1207,8 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
 
         // offset is 0 for the first written record
         assertEquals(sink.currentOffset(topicName, partition), 0);
+        // currentOffsets() should include the first record (offset 0) when processed by ackUntil
+        assertEquals(sink.taskContext.currentOffsets().size(), 1);
 
         entryId.set(1);
         sink.write(record);


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #23

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
[PulsarKafkaSinkTaskContext.currentOffsets()](https://github.com/apache/pulsar-connectors/blob/b8760955f20db284c7779e38ca993ecedb5e563c/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java#L126) was filtering out offsets equal to `0` by only including values greater than `0`. This caused the first record in a partition, whose offset can legitimately be `0`, to be omitted from the offsets snapshot returned to [KafkaConnectSink#flush()](https://github.com/apache/pulsar-connectors/blob/b8760955f20db284c7779e38ca993ecedb5e563c/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java#L242). As a result, the acknowledgment for that record was not flushed until a later record with a non-zero offset was processed.

This change ensures that offset `0` is treated as a valid offset and is included in the current offsets map, so the first record can be acknowledged without waiting for another record.

### Modifications

<!-- Describe the modifications you've done. -->
The offset filter in PulsarKafkaSinkTaskContext.currentOffsets() was changed from:
`if (offset > 0) {`
to:
`if (offset >= 0) {`

This includes records with offset `0` in the returned snapshot.
A assertion was added to existing `offsetTest` in `KafkaConnectSinkTest` to verify that `currentOffsets()` contains that record and reports offset 0 correctly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *org.apache.pulsar.io.kafka.connect.KafkaConnectSinkTest#offsetTest* (updated existing test)

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/cognitree/pulsar-connectors/pull/6
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
