### PR TITLE
[fix][io] Fix Solr Sink KeyValue schema unwrapping for Debezium CDC

### DIFF
--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrAbstractSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrAbstractSink.java
@@ -42,7 +42,7 @@ import org.apache.solr.common.SolrInputDocument;
 @Slf4j
 public abstract class SolrAbstractSink<T> implements Sink<T> {
 
-    private SolrSinkConfig solrSinkConfig;
+    protected SolrSinkConfig solrSinkConfig;
     private SolrClient client;
     private boolean enableBasicAuth;
 
@@ -78,6 +78,11 @@ public abstract class SolrAbstractSink<T> implements Sink<T> {
         }
 
         SolrInputDocument document = convert(record);
+        if (document == null) {
+            log.error("Failed to convert record: {}", record);
+            record.ack();
+            return;
+        }
         updateRequest.add(document);
 
         try {
@@ -102,6 +107,10 @@ public abstract class SolrAbstractSink<T> implements Sink<T> {
 
     // convert record as a Solr document
     public abstract SolrInputDocument convert(Record<T> message);
+
+    protected SolrClient getSolrClient() {
+        return client;
+    }
 
     public static SolrClient getClient(SolrMode solrMode, String url) {
         SolrClient solrClient = null;

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrAbstractSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrAbstractSink.java
@@ -77,13 +77,19 @@ public abstract class SolrAbstractSink<T> implements Sink<T> {
             );
         }
 
-        SolrInputDocument document = convert(record);
-        if (document == null) {
-            log.error("Failed to convert record: {}", record);
-            record.ack();
+        try {
+            SolrInputDocument document = convert(record);
+            if (document == null) {
+                // It was a DELETE event or a skip, Acknowledge it so it isn't retried
+                record.ack();
+                return;
+            }
+            updateRequest.add(document);
+        } catch (Exception e) {
+            log.error("Failed to convert record: {}", record, e);
+            record.fail();
             return;
         }
-        updateRequest.add(document);
 
         try {
             UpdateResponse updateResponse = updateRequest.process(client, solrSinkConfig.getSolrCollection());

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
@@ -39,10 +39,16 @@ import org.apache.solr.common.SolrInputDocument;
 )
 @Slf4j
 public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
+
+    /**
+     * Entry point for conversion. Determines if the record requires CDC unwrapping
+     * based on user configuration.
+     */
     @Override
     public SolrInputDocument convert(Record<GenericRecord> pulsarRecord) {
         SolrInputDocument solrDocument = new SolrInputDocument();
         GenericRecord messageValue = pulsarRecord.getValue();
+
         if (solrSinkConfig != null && solrSinkConfig.isUnwrapDebeziumRecord()) {
             return mapDebeziumPayload(messageValue, solrDocument);
         }
@@ -52,16 +58,22 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
         return solrDocument;
     }
 
+    /**
+     * Orchestrates the Debezium extraction process and ensures processing errors
+     * are thrown to trigger Pulsar's failure handling.
+     */
     private SolrInputDocument mapDebeziumPayload(GenericRecord rootRecord, SolrInputDocument solrDocument) {
         try {
             GenericRecord payloadRecord = extractValueRecord(rootRecord);
 
             if (isDebeziumEnvelope(payloadRecord)) {
                 payloadRecord = extractAfterRecord(payloadRecord, solrDocument);
+                // Return null if extractAfterRecord handled a DELETE or skipped the record
                 if (payloadRecord == null) {
                     return null;
                 }
             }
+
             populateSolrFields(payloadRecord, solrDocument);
             return solrDocument;
         } catch (Exception ex) {
@@ -70,15 +82,23 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
         }
     }
 
+    /**
+     * Handles Pulsar's KeyValue schema by checking the native object and
+     * extracting the 'Value' part of the pair.
+     */
     private GenericRecord extractValueRecord(GenericRecord rootRecord) {
         Object nativePayload = rootRecord.getNativeObject();
-        if (nativePayload instanceof KeyValue) {
-            Object valuePart = ((KeyValue<?, ?>) nativePayload).getValue();
-            if (valuePart instanceof GenericRecord) {
-                log.debug("Detected KeyValue wrapper, extracting value section");
-                return (GenericRecord) valuePart;
-            }
+
+        if (!(nativePayload instanceof KeyValue)) {
+            return rootRecord;
         }
+
+        Object valuePart = ((KeyValue<?, ?>) nativePayload).getValue();
+        if (valuePart instanceof GenericRecord) {
+            log.debug("Detected KeyValue wrapper, extracting value section");
+            return (GenericRecord) valuePart;
+        }
+
         return rootRecord;
     }
 
@@ -101,60 +121,72 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
             else if ("op".equals(fieldName)) hasOp = true;
         }
 
-        // A CDC envelope will contain these Debezium operational fields
+        // A CDC envelope must strictly contain the operation code and a data state
         return (hasAfter || hasBefore) && hasOp;
     }
 
+    /**
+     * Separates the INSERT/UPDATE path from the DELETE path.
+     * Issues immediate deletions to Solr for DELETE events.
+     */
     private GenericRecord extractAfterRecord(GenericRecord envelopeRecord, SolrInputDocument solrDocument) {
         Object afterField = envelopeRecord.getField("after");
 
-        if (afterField == null) {
-            log.debug("Debezium DELETE event detected, Processing deletion");
+        if (afterField != null) {
+            return (afterField instanceof GenericRecord) ? (GenericRecord) afterField : envelopeRecord;
+        }
 
-            Object beforeField = envelopeRecord.getField("before");
-            if (beforeField instanceof GenericRecord) {
-                GenericRecord beforeRecord = (GenericRecord) beforeField;
+        // Processing Debezium DELETE path (where 'after' is null)
+        log.debug("Debezium DELETE event detected, Processing deletion");
+        Object beforeField = envelopeRecord.getField("before");
 
-                // Dynamically extract the primary key
-                List<Field> fields = beforeRecord.getFields();
-                if (!fields.isEmpty()) {
-                    Object id = beforeRecord.getField(fields.get(0));
-
-                    if (id != null) {
-                        try {
-                            int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
-                                    ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
-
-                            getSolrClient().deleteById(String.valueOf(id), commitWithinMs);
-                            log.debug("Successfully issued delete to Solr for id={} with commitWithinMs={}",
-                                    id, commitWithinMs);
-                        } catch (Exception e) {
-                            log.error("Failed to delete document from Solr for id={}", id, e);
-                        }
-                    } else {
-                        log.warn("DELETE event received, but primary key field was null.");
-                    }
-                } else {
-                    log.warn("DELETE event received, but 'before' record had no fields.");
-                }
-            } else {
-                log.warn("DELETE event received, but 'before' field is not a GenericRecord.");
-            }
-
+        if (!(beforeField instanceof GenericRecord)) {
+            log.warn("DELETE event received, but 'before' field is missing or invalid.");
             return null;
         }
 
-        if (afterField instanceof GenericRecord) {
-            log.debug("Debezium envelope detected, extracting 'after' payload");
-            return (GenericRecord) afterField;
+        GenericRecord beforeRecord = (GenericRecord) beforeField;
+        List<Field> fields = beforeRecord.getFields();
+
+        if (fields.isEmpty()) {
+            log.warn("DELETE event received, but 'before' record has no fields to extract ID.");
+            return null;
         }
 
-        return envelopeRecord;
+        // Assumes index 0 is the Primary Key per standard Debezium behavior
+        Object id = beforeRecord.getField(fields.get(0));
+        if (id == null) {
+            log.warn("DELETE event received, but primary key field value was null.");
+            return null;
+        }
+
+        executeSolrDelete(id);
+        return null;
     }
 
+    /**
+     * Helper to issue delete commands to the SolrClient using configured commit settings.
+     */
+    private void executeSolrDelete(Object id) {
+        try {
+            int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
+                    ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
+
+            getSolrClient().deleteById(String.valueOf(id), commitWithinMs);
+            log.debug("Successfully issued delete to Solr for id={} with commitWithinMs={}", id, commitWithinMs);
+        } catch (Exception e) {
+            log.error("Failed to delete document from Solr for id={}", id, e);
+        }
+    }
+
+    /**
+     * Iterates through all fields in a GenericRecord to build the Solr document,
+     * applying type normalization to each value.
+     */
     private void populateSolrFields(GenericRecord dataRecord, SolrInputDocument solrDocument) {
         for (Field field : dataRecord.getFields()) {
             Object rawValue = dataRecord.getField(field);
+            // Skip nulls and nested records as Solr requires flat field values
             if (rawValue == null || rawValue instanceof GenericRecord) {
                 continue;
             }
@@ -162,6 +194,10 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
         }
     }
 
+    /**
+     * Ensures numeric types are safely coerced to Strings to maintain
+     * compatibility with Solr's field requirements.
+     */
     private Object normalizeValue(Object value) {
         if (value instanceof Integer || value instanceof Long) {
             return String.valueOf(value);

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
@@ -47,13 +47,8 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
             return mapDebeziumPayload(messageValue, solrDocument);
         }
 
-        // Default mapping for non-CDC messages
-        for (Field recordField : messageValue.getFields()) {
-            Object fieldValue = messageValue.getField(recordField);
-            if (fieldValue != null) {
-                solrDocument.setField(recordField.getName(), fieldValue);
-            }
-        }
+        // Default mapping for non-CDC messages now uses the same safe population logic
+        populateSolrFields(messageValue, solrDocument);
         return solrDocument;
     }
 
@@ -64,14 +59,14 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
             if (containsAfterField(payloadRecord)) {
                 payloadRecord = extractAfterRecord(payloadRecord, solrDocument);
                 if (payloadRecord == null) {
-                    return solrDocument;
+                    return null;
                 }
             }
             populateSolrFields(payloadRecord, solrDocument);
             return solrDocument;
         } catch (Exception ex) {
             log.error("Debezium record processing failed, returning empty Solr document", ex);
-            return solrDocument;
+            return null;
         }
     }
 
@@ -98,36 +93,48 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
 
     private GenericRecord extractAfterRecord(GenericRecord envelopeRecord, SolrInputDocument solrDocument) {
         Object afterField = envelopeRecord.getField("after");
+
         if (afterField == null) {
-            log.info("Debezium DELETE event detected, Processing deletion");
+            log.debug("Debezium DELETE event detected, Processing deletion");
 
             Object beforeField = envelopeRecord.getField("before");
             if (beforeField instanceof GenericRecord) {
                 GenericRecord beforeRecord = (GenericRecord) beforeField;
-                Object id = beforeRecord.getField("id");
 
-                if (id != null) {
-                    try {
-                        int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
-                                ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
-                        getSolrClient().deleteById(String.valueOf(id), commitWithinMs);
-                        log.info("Successfully issued delete to Solr for id={} with commitWithinMs={}",
-                                id, commitWithinMs);
-                    } catch (Exception e) {
-                        log.error("Failed to delete document from Solr for id={}", id, e);
+                // Dynamically extract the primary key
+                List<Field> fields = beforeRecord.getFields();
+                if (!fields.isEmpty()) {
+                    Object id = beforeRecord.getField(fields.get(0));
+
+                    if (id != null) {
+                        try {
+                            int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
+                                    ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
+
+                            getSolrClient().deleteById(String.valueOf(id), commitWithinMs);
+                            log.debug("Successfully issued delete to Solr for id={} with commitWithinMs={}",
+                                    id, commitWithinMs);
+                        } catch (Exception e) {
+                            log.error("Failed to delete document from Solr for id={}", id, e);
+                        }
+                    } else {
+                        log.warn("DELETE event received, but primary key field was null.");
                     }
                 } else {
-                    log.warn("DELETE event received, but 'id' field was missing or null in the 'before' record.");
+                    log.warn("DELETE event received, but 'before' record had no fields.");
                 }
             } else {
                 log.warn("DELETE event received, but 'before' field is not a GenericRecord.");
             }
+
             return null;
         }
+
         if (afterField instanceof GenericRecord) {
             log.debug("Debezium envelope detected, extracting 'after' payload");
             return (GenericRecord) afterField;
         }
+
         return envelopeRecord;
     }
 

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
@@ -53,8 +53,10 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
             return mapDebeziumPayload(messageValue, solrDocument);
         }
 
-        // Default mapping for non-CDC messages now uses the same safe population logic
-        populateSolrFields(messageValue, solrDocument);
+        // Legacy mapping for non-CDC messages to maintain backward compatibility
+        for (Field field : messageValue.getFields()) {
+            solrDocument.setField(field.getName(), messageValue.getField(field));
+        }
         return solrDocument;
     }
 
@@ -141,16 +143,16 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
         Object beforeField = envelopeRecord.getField("before");
 
         if (!(beforeField instanceof GenericRecord)) {
-            log.warn("DELETE event received, but 'before' field is missing or invalid.");
-            return null;
+            throw new IllegalArgumentException("DELETE event received, but 'before' field is missing or invalid.");
         }
 
         GenericRecord beforeRecord = (GenericRecord) beforeField;
         List<Field> fields = beforeRecord.getFields();
 
         if (fields.isEmpty()) {
-            log.warn("DELETE event received, but 'before' record has no fields to extract ID.");
-            return null;
+            throw new IllegalArgumentException(
+                    "DELETE event received, but 'before' record has no fields to extract ID."
+            );
         }
 
         // Safe identifier lookup strategy: Look for a field explicitly named "id" first
@@ -161,8 +163,7 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
 
         Object id = beforeRecord.getField(targetIdField);
         if (id == null) {
-            log.warn("DELETE event received, but primary key field value was null.");
-            return null;
+            throw new IllegalArgumentException("DELETE event received, but primary key field value was null.");
         }
 
         // We now let the exception bubble up to mapDebeziumPayload so the parent class fails the record
@@ -215,7 +216,7 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
      * compatibility with Solr's field requirements.
      */
     private Object normalizeValue(Object value) {
-        if (value instanceof Integer || value instanceof Long) {
+        if (value instanceof Number) {
             return String.valueOf(value);
         }
         return value;

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
@@ -39,14 +40,111 @@ import org.apache.solr.common.SolrInputDocument;
 @Slf4j
 public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
     @Override
-    public SolrInputDocument convert(Record<GenericRecord> message) {
-        SolrInputDocument doc = new SolrInputDocument();
-        GenericRecord record = message.getValue();
-        List<Field> fields = record.getFields();
-        for (Field field : fields) {
-            Object fieldValue = record.getField(field);
-            doc.setField(field.getName(), fieldValue);
+    public SolrInputDocument convert(Record<GenericRecord> pulsarRecord) {
+        SolrInputDocument solrDocument = new SolrInputDocument();
+        GenericRecord messageValue = pulsarRecord.getValue();
+        if (solrSinkConfig != null && solrSinkConfig.isUnwrapDebeziumRecord()) {
+            return mapDebeziumPayload(messageValue, solrDocument);
         }
-        return doc;
+
+        // Default mapping for non-CDC messages
+        for (Field recordField : messageValue.getFields()) {
+            Object fieldValue = messageValue.getField(recordField);
+            if (fieldValue != null) {
+                solrDocument.setField(recordField.getName(), fieldValue);
+            }
+        }
+        return solrDocument;
+    }
+
+    private SolrInputDocument mapDebeziumPayload(GenericRecord rootRecord, SolrInputDocument solrDocument) {
+        try {
+            GenericRecord payloadRecord = extractValueRecord(rootRecord);
+
+            if (containsAfterField(payloadRecord)) {
+                payloadRecord = extractAfterRecord(payloadRecord, solrDocument);
+                if (payloadRecord == null) {
+                    return solrDocument;
+                }
+            }
+            populateSolrFields(payloadRecord, solrDocument);
+            return solrDocument;
+        } catch (Exception ex) {
+            log.error("Debezium record processing failed, returning empty Solr document", ex);
+            return solrDocument;
+        }
+    }
+
+    private GenericRecord extractValueRecord(GenericRecord rootRecord) {
+        Object nativePayload = rootRecord.getNativeObject();
+        if (nativePayload instanceof KeyValue) {
+            Object valuePart = ((KeyValue<?, ?>) nativePayload).getValue();
+            if (valuePart instanceof GenericRecord) {
+                log.debug("Detected KeyValue wrapper, extracting value section");
+                return (GenericRecord) valuePart;
+            }
+        }
+        return rootRecord;
+    }
+
+    private boolean containsAfterField(GenericRecord record) {
+        for (Field field : record.getFields()) {
+            if ("after".equals(field.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private GenericRecord extractAfterRecord(GenericRecord envelopeRecord, SolrInputDocument solrDocument) {
+        Object afterField = envelopeRecord.getField("after");
+        if (afterField == null) {
+            log.info("Debezium DELETE event detected, Processing deletion");
+
+            Object beforeField = envelopeRecord.getField("before");
+            if (beforeField instanceof GenericRecord) {
+                GenericRecord beforeRecord = (GenericRecord) beforeField;
+                Object id = beforeRecord.getField("id");
+
+                if (id != null) {
+                    try {
+                        int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
+                                ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
+                        getSolrClient().deleteById(String.valueOf(id), commitWithinMs);
+                        log.info("Successfully issued delete to Solr for id={} with commitWithinMs={}",
+                                id, commitWithinMs);
+                    } catch (Exception e) {
+                        log.error("Failed to delete document from Solr for id={}", id, e);
+                    }
+                } else {
+                    log.warn("DELETE event received, but 'id' field was missing or null in the 'before' record.");
+                }
+            } else {
+                log.warn("DELETE event received, but 'before' field is not a GenericRecord.");
+            }
+            return null;
+        }
+        if (afterField instanceof GenericRecord) {
+            log.debug("Debezium envelope detected, extracting 'after' payload");
+            return (GenericRecord) afterField;
+        }
+        return envelopeRecord;
+    }
+
+    private void populateSolrFields(GenericRecord dataRecord, SolrInputDocument solrDocument) {
+        for (Field field : dataRecord.getFields()) {
+            Object rawValue = dataRecord.getField(field);
+            if (rawValue == null || rawValue instanceof GenericRecord) {
+                continue;
+            }
+            solrDocument.setField(field.getName(), normalizeValue(rawValue));
+        }
+    }
+
+    private Object normalizeValue(Object value) {
+        if (value instanceof Integer || value instanceof Long) {
+            return String.valueOf(value);
+        }
+        return value;
     }
 }

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
@@ -153,30 +153,46 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
             return null;
         }
 
-        // Assumes index 0 is the Primary Key per standard Debezium behavior
-        Object id = beforeRecord.getField(fields.get(0));
+        // Safe identifier lookup strategy: Look for a field explicitly named "id" first
+        Field targetIdField = fields.stream()
+                .filter(f -> "id".equals(f.getName()))
+                .findFirst()
+                .orElse(fields.get(0));
+
+        Object id = beforeRecord.getField(targetIdField);
         if (id == null) {
             log.warn("DELETE event received, but primary key field value was null.");
             return null;
         }
 
-        executeSolrDelete(id);
+        // We now let the exception bubble up to mapDebeziumPayload so the parent class fails the record
+        try {
+            executeSolrDelete(id);
+        } catch (Exception e) {
+            log.error("Failed to propagate document deletion to Solr for id={}", id, e);
+            throw new RuntimeException("Solr deletion failed", e);
+        }
+
         return null;
     }
 
     /**
-     * Helper to issue delete commands to the SolrClient using configured commit settings.
+     * Helper to issue delete commands via an UpdateRequest against the targeted collection.
+     * Throws an exception on failure to ensure proper Pulsar record lifecycle fail/retry.
      */
-    private void executeSolrDelete(Object id) {
-        try {
-            int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
-                    ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
+    private void executeSolrDelete(Object id) throws Exception {
+        int commitWithinMs = (solrSinkConfig != null && solrSinkConfig.getSolrCommitWithinMs() > 0)
+                ? solrSinkConfig.getSolrCommitWithinMs() : 1000;
 
-            getSolrClient().deleteById(String.valueOf(id), commitWithinMs);
-            log.debug("Successfully issued delete to Solr for id={} with commitWithinMs={}", id, commitWithinMs);
-        } catch (Exception e) {
-            log.error("Failed to delete document from Solr for id={}", id, e);
-        }
+        org.apache.solr.client.solrj.request.UpdateRequest deleteRequest =
+                new org.apache.solr.client.solrj.request.UpdateRequest();
+
+        deleteRequest.deleteById(String.valueOf(id));
+        deleteRequest.setCommitWithin(commitWithinMs);
+
+        // Processes the request against the explicit collection, honoring client auth settings
+        deleteRequest.process(getSolrClient(), solrSinkConfig.getSolrCollection());
+        log.debug("Successfully issued delete to Solr for id={} with commitWithinMs={}", id, commitWithinMs);
     }
 
     /**

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrGenericRecordSink.java
@@ -56,7 +56,7 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
         try {
             GenericRecord payloadRecord = extractValueRecord(rootRecord);
 
-            if (containsAfterField(payloadRecord)) {
+            if (isDebeziumEnvelope(payloadRecord)) {
                 payloadRecord = extractAfterRecord(payloadRecord, solrDocument);
                 if (payloadRecord == null) {
                     return null;
@@ -65,8 +65,8 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
             populateSolrFields(payloadRecord, solrDocument);
             return solrDocument;
         } catch (Exception ex) {
-            log.error("Debezium record processing failed, returning empty Solr document", ex);
-            return null;
+            log.error("Debezium record processing failed", ex);
+            throw new RuntimeException("Failed to extract Debezium payload", ex);
         }
     }
 
@@ -82,13 +82,27 @@ public class SolrGenericRecordSink extends SolrAbstractSink<GenericRecord> {
         return rootRecord;
     }
 
-    private boolean containsAfterField(GenericRecord record) {
+    /**
+     * Identifies if the record is a Debezium CDC envelope.
+     * Debezium envelopes signify state changes and contain specific metadata fields.
+     * The "after" field signifies the newest state of the database row after an insert/update.
+     * We check for the presence of standard CDC fields to differentiate a true envelope
+     * from a normal database table that simply happens to have a column named "after".
+     */
+    private boolean isDebeziumEnvelope(GenericRecord record) {
+        boolean hasAfter = false;
+        boolean hasBefore = false;
+        boolean hasOp = false;
+
         for (Field field : record.getFields()) {
-            if ("after".equals(field.getName())) {
-                return true;
-            }
+            String fieldName = field.getName();
+            if ("after".equals(fieldName)) hasAfter = true;
+            else if ("before".equals(fieldName)) hasBefore = true;
+            else if ("op".equals(fieldName)) hasOp = true;
         }
-        return false;
+
+        // A CDC envelope will contain these Debezium operational fields
+        return (hasAfter || hasBefore) && hasOp;
     }
 
     private GenericRecord extractAfterRecord(GenericRecord envelopeRecord, SolrInputDocument solrDocument) {

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrSinkConfig.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrSinkConfig.java
@@ -81,6 +81,13 @@ public class SolrSinkConfig implements Serializable {
         help = "The password to use for basic authentication")
     private String password;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "If true, the sink will attempt to extract the nested 'after' field from CDC/Debezium records."
+    )
+    private boolean unwrapDebeziumRecord = false;
+
     public static SolrSinkConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), SolrSinkConfig.class);

--- a/solr/src/main/java/org/apache/pulsar/io/solr/SolrSinkConfig.java
+++ b/solr/src/main/java/org/apache/pulsar/io/solr/SolrSinkConfig.java
@@ -84,7 +84,8 @@ public class SolrSinkConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "false",
-            help = "If true, the sink will attempt to extract the nested 'after' field from CDC/Debezium records."
+            help = "If true, the sink will unwrap Debezium CDC records (including KeyValue payloads) and " +
+                    "index the row state from the 'after' field; DELETE events are propagated as Solr deletes."
     )
     private boolean unwrapDebeziumRecord = false;
 

--- a/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -51,6 +51,8 @@ public class SolrGenericRecordSinkTest {
 
     private SolrServerUtil solrServerUtil;
     private Message<GenericRecord> message;
+    private SolrGenericRecordSink sink;
+    private Map<String, Object> configs;
 
     /**
      * A Simple class to test solr class.
@@ -65,6 +67,14 @@ public class SolrGenericRecordSinkTest {
     public void setUp() throws Exception {
         solrServerUtil = new SolrServerUtil(8983);
         solrServerUtil.startStandaloneSolr();
+        sink = new SolrGenericRecordSink();
+        configs = new HashMap<>();
+        configs.put("solrUrl", "http://localhost:8983/solr");
+        configs.put("solrMode", "Standalone");
+        configs.put("solrCollection", "techproducts");
+        configs.put("solrCommitWithinMs", "100");
+        configs.put("username", "");
+        configs.put("password", "");
     }
 
     @AfterMethod(alwaysRun = true)
@@ -75,13 +85,6 @@ public class SolrGenericRecordSinkTest {
     @Test
     public void testOpenAndWriteSink() throws Exception {
         message = mock(MessageImpl.class);
-        Map<String, Object> configs = new HashMap<>();
-        configs.put("solrUrl", "http://localhost:8983/solr");
-        configs.put("solrMode", "Standalone");
-        configs.put("solrCollection", "techproducts");
-        configs.put("solrCommitWithinMs", "100");
-        configs.put("username", "");
-        configs.put("password", "");
         GenericSchema<GenericRecord> genericAvroSchema;
 
         SolrGenericRecordSink sink = new SolrGenericRecordSink();
@@ -118,14 +121,6 @@ public class SolrGenericRecordSinkTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testDebeziumUnwrapEnvelope() throws Exception {
-        SolrGenericRecordSink sink = new SolrGenericRecordSink();
-        Map<String, Object> configs = new HashMap<>();
-        configs.put("solrUrl", "http://localhost:8983/solr");
-        configs.put("solrMode", "Standalone");
-        configs.put("solrCollection", "techproducts");
-        configs.put("solrCommitWithinMs", "100");
-        configs.put("username", "");
-        configs.put("password", "");
         configs.put("unwrapDebeziumRecord", true);
         sink.open(configs, null);
 
@@ -136,12 +131,12 @@ public class SolrGenericRecordSinkTest {
 
         GenericRecord mockValueRecord = mock(GenericRecord.class);
         when(mockRootRecord.getNativeObject()).thenReturn(new KeyValue<>("key", mockValueRecord));
-        // containsAfterField() iterates getFields() — must include "after" field here
+        // containsAfterField() iterates getFields() - must include "after" field here
         Field afterSchemaField = mock(Field.class);
         when(afterSchemaField.getName()).thenReturn("after");
         when(mockValueRecord.getFields()).thenReturn(Arrays.asList(afterSchemaField));
 
-        // extractAfterRecord() calls getField("after") by string — return nested record
+        // extractAfterRecord() calls getField("after") by string - return nested record
         GenericRecord mockAfterRecord = mock(GenericRecord.class);
         when(mockValueRecord.getField("after")).thenReturn(mockAfterRecord);
 
@@ -164,14 +159,6 @@ public class SolrGenericRecordSinkTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testDebeziumUnwrapFlatValue() throws Exception {
-        SolrGenericRecordSink sink = new SolrGenericRecordSink();
-        Map<String, Object> configs = new HashMap<>();
-        configs.put("solrUrl", "http://localhost:8983/solr");
-        configs.put("solrMode", "Standalone");
-        configs.put("solrCollection", "techproducts");
-        configs.put("solrCommitWithinMs", "100");
-        configs.put("username", "");
-        configs.put("password", "");
         configs.put("unwrapDebeziumRecord", true);
         sink.open(configs, null);
 
@@ -183,7 +170,7 @@ public class SolrGenericRecordSinkTest {
         GenericRecord mockValueRecord = mock(GenericRecord.class);
         when(mockRootRecord.getNativeObject()).thenReturn(new KeyValue<>("key", mockValueRecord));
 
-        // containsAfterField() will iterate these — no "after" field, so flat path is taken
+        // containsAfterField() will iterate these, no "after" field, so flat path is taken
         Field idField = mock(Field.class);
         when(idField.getName()).thenReturn("id");
         Field profileIdField = mock(Field.class);

--- a/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -134,7 +134,9 @@ public class SolrGenericRecordSinkTest {
         // containsAfterField() iterates getFields() - must include "after" field here
         Field afterSchemaField = mock(Field.class);
         when(afterSchemaField.getName()).thenReturn("after");
-        when(mockValueRecord.getFields()).thenReturn(Arrays.asList(afterSchemaField));
+        Field opField = mock(Field.class);
+        when(opField.getName()).thenReturn("op");
+        when(mockValueRecord.getFields()).thenReturn(Arrays.asList(afterSchemaField, opField));
 
         // extractAfterRecord() calls getField("after") by string - return nested record
         GenericRecord mockAfterRecord = mock(GenericRecord.class);

--- a/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -189,4 +189,44 @@ public class SolrGenericRecordSinkTest {
         Assert.assertEquals(doc.getFieldValue("profile_id"), "801");
         Assert.assertNull(doc.getFieldValue("user_id"), "user_id was not provided, should be null");
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDebeziumUnwrapDelete() throws Exception {
+        configs.put("unwrapDebeziumRecord", true);
+        sink.open(configs, null);
+
+        // Build root record
+        GenericRecord mockRootRecord = mock(GenericRecord.class);
+        Record<GenericRecord> mockMessage = mock(Record.class);
+        when(mockMessage.getValue()).thenReturn(mockRootRecord);
+
+        GenericRecord mockValueRecord = mock(GenericRecord.class);
+        when(mockRootRecord.getNativeObject()).thenReturn(new KeyValue<>("key", mockValueRecord));
+
+        // Mock Debezium DELETE signature: 'after' is null, 'before' and 'op' are present
+        Field beforeSchemaField = mock(Field.class);
+        when(beforeSchemaField.getName()).thenReturn("before");
+        Field opField = mock(Field.class);
+        when(opField.getName()).thenReturn("op");
+        when(mockValueRecord.getFields()).thenReturn(Arrays.asList(beforeSchemaField, opField));
+
+        // 'after' is null for deletes
+        when(mockValueRecord.getField("after")).thenReturn(null);
+
+        // Mock 'before' record containing the ID to be deleted
+        GenericRecord mockBeforeRecord = mock(GenericRecord.class);
+        when(mockValueRecord.getField("before")).thenReturn(mockBeforeRecord);
+
+        Field idField = mock(Field.class);
+        when(idField.getName()).thenReturn("id");
+        when(mockBeforeRecord.getFields()).thenReturn(Arrays.asList(idField));
+        when(mockBeforeRecord.getField(idField)).thenReturn(500);
+
+        // This should trigger executeSolrDelete and return null
+        SolrInputDocument doc = sink.convert(mockMessage);
+
+        // In our refactored logic, a DELETE returns null so the parent class can ACK it
+        Assert.assertNull(doc, "Document should be null for DELETE events to trigger ACK");
+    }
 }

--- a/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -18,7 +18,11 @@
  */
 package org.apache.pulsar.io.solr;
 
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,7 +42,9 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.NamedList;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -198,6 +204,8 @@ public class SolrGenericRecordSinkTest {
 
         // Create a mocked SolrClient to simulate a successful network response
         SolrClient mockSolrClient = mock(SolrClient.class);
+        when(mockSolrClient.request(any(SolrRequest.class), eq("techproducts")))
+                .thenReturn(new NamedList<>());
 
         // Override getSolrClient to inject our mock and bypass real HTTP calls
         SolrGenericRecordSink mockNetworkSink = new SolrGenericRecordSink() {
@@ -238,6 +246,9 @@ public class SolrGenericRecordSinkTest {
 
         // Process the convert using the mocked network sink
         SolrInputDocument doc = mockNetworkSink.convert(mockMessage);
+
+        // Verify that the deletion request was actually issued to the mocked Solr client
+        verify(mockSolrClient).request(any(SolrRequest.class), eq("techproducts"));
 
         // In our refactored logic, a DELETE returns null so the parent class can ACK it
         Assert.assertNull(doc, "Document should be null for DELETE events to trigger ACK");

--- a/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.common.SolrInputDocument;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -194,7 +195,19 @@ public class SolrGenericRecordSinkTest {
     @SuppressWarnings("unchecked")
     public void testDebeziumUnwrapDelete() throws Exception {
         configs.put("unwrapDebeziumRecord", true);
-        sink.open(configs, null);
+
+        // Create a mocked SolrClient to simulate a successful network response
+        SolrClient mockSolrClient = mock(SolrClient.class);
+
+        // Override getSolrClient to inject our mock and bypass real HTTP calls
+        SolrGenericRecordSink mockNetworkSink = new SolrGenericRecordSink() {
+            @Override
+            protected SolrClient getSolrClient() {
+                return mockSolrClient;
+            }
+        };
+
+        mockNetworkSink.open(configs, null);
 
         // Build root record
         GenericRecord mockRootRecord = mock(GenericRecord.class);
@@ -223,8 +236,8 @@ public class SolrGenericRecordSinkTest {
         when(mockBeforeRecord.getFields()).thenReturn(Arrays.asList(idField));
         when(mockBeforeRecord.getField(idField)).thenReturn(500);
 
-        // This should trigger executeSolrDelete and return null
-        SolrInputDocument doc = sink.convert(mockMessage);
+        // Process the convert using the mocked network sink
+        SolrInputDocument doc = mockNetworkSink.convert(mockMessage);
 
         // In our refactored logic, a DELETE returns null so the parent class can ACK it
         Assert.assertNull(doc, "Document should be null for DELETE events to trigger ACK");

--- a/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -20,11 +20,13 @@ package org.apache.pulsar.io.solr;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -32,8 +34,11 @@ import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
+import org.apache.solr.common.SolrInputDocument;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -108,5 +113,91 @@ public class SolrGenericRecordSinkTest {
 
         // open should success
         sink.open(configs, null);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDebeziumUnwrapEnvelope() throws Exception {
+        SolrGenericRecordSink sink = new SolrGenericRecordSink();
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("solrUrl", "http://localhost:8983/solr");
+        configs.put("solrMode", "Standalone");
+        configs.put("solrCollection", "techproducts");
+        configs.put("solrCommitWithinMs", "100");
+        configs.put("username", "");
+        configs.put("password", "");
+        configs.put("unwrapDebeziumRecord", true);
+        sink.open(configs, null);
+
+        // Build root record wrapping a KeyValue payload
+        GenericRecord mockRootRecord = mock(GenericRecord.class);
+        Record<GenericRecord> mockMessage = mock(Record.class);
+        when(mockMessage.getValue()).thenReturn(mockRootRecord);
+
+        GenericRecord mockValueRecord = mock(GenericRecord.class);
+        when(mockRootRecord.getNativeObject()).thenReturn(new KeyValue<>("key", mockValueRecord));
+        // containsAfterField() iterates getFields() — must include "after" field here
+        Field afterSchemaField = mock(Field.class);
+        when(afterSchemaField.getName()).thenReturn("after");
+        when(mockValueRecord.getFields()).thenReturn(Arrays.asList(afterSchemaField));
+
+        // extractAfterRecord() calls getField("after") by string — return nested record
+        GenericRecord mockAfterRecord = mock(GenericRecord.class);
+        when(mockValueRecord.getField("after")).thenReturn(mockAfterRecord);
+
+        // Fields inside the "after" payload to be mapped into Solr document
+        Field idField = mock(Field.class);
+        when(idField.getName()).thenReturn("id");
+        Field userIdField = mock(Field.class);
+        when(userIdField.getName()).thenReturn("user_id");
+        when(mockAfterRecord.getFields()).thenReturn(Arrays.asList(idField, userIdField));
+        when(mockAfterRecord.getField(idField)).thenReturn(100);
+        when(mockAfterRecord.getField(userIdField)).thenReturn(999);
+
+        SolrInputDocument doc = sink.convert(mockMessage);
+
+        Assert.assertNotNull(doc, "Document should not be null for envelope with 'after' field");
+        Assert.assertEquals(doc.getFieldValue("id"), "100");
+        Assert.assertEquals(doc.getFieldValue("user_id"), "999");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDebeziumUnwrapFlatValue() throws Exception {
+        SolrGenericRecordSink sink = new SolrGenericRecordSink();
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("solrUrl", "http://localhost:8983/solr");
+        configs.put("solrMode", "Standalone");
+        configs.put("solrCollection", "techproducts");
+        configs.put("solrCommitWithinMs", "100");
+        configs.put("username", "");
+        configs.put("password", "");
+        configs.put("unwrapDebeziumRecord", true);
+        sink.open(configs, null);
+
+        // Build root record wrapping a KeyValue payload
+        GenericRecord mockRootRecord = mock(GenericRecord.class);
+        Record<GenericRecord> mockMessage = mock(Record.class);
+        when(mockMessage.getValue()).thenReturn(mockRootRecord);
+
+        GenericRecord mockValueRecord = mock(GenericRecord.class);
+        when(mockRootRecord.getNativeObject()).thenReturn(new KeyValue<>("key", mockValueRecord));
+
+        // containsAfterField() will iterate these — no "after" field, so flat path is taken
+        Field idField = mock(Field.class);
+        when(idField.getName()).thenReturn("id");
+        Field profileIdField = mock(Field.class);
+        when(profileIdField.getName()).thenReturn("profile_id");
+        when(mockValueRecord.getFields()).thenReturn(Arrays.asList(idField, profileIdField));
+
+        // populateSolrFields() reads values by Field object reference
+        when(mockValueRecord.getField(idField)).thenReturn(200);
+        when(mockValueRecord.getField(profileIdField)).thenReturn(801);
+        SolrInputDocument doc = sink.convert(mockMessage);
+
+        Assert.assertNotNull(doc, "Document should not be null for flat value record");
+        Assert.assertEquals(doc.getFieldValue("id"), "200");
+        Assert.assertEquals(doc.getFieldValue("profile_id"), "801");
+        Assert.assertNull(doc.getFieldValue("user_id"), "user_id was not provided, should be null");
     }
 }


### PR DESCRIPTION
Fixes [apache#23763](https://github.com/apache/pulsar/issues/23763)

### Motivation

Solr sink indexing remains empty when consuming PostgreSQL CDC events produced by the Debezium connector.

The root cause is a schema and structural incompatibility between Debezium-generated messages and the existing Solr sink implementation:

- **KeyValue schema handling:** Debezium emits CDC events using a `KeyValue` schema wrapper. The existing `GenericRecord` processing could not correctly extract nested payload fields from this structure.
- **Envelope structure:** Debezium wraps events inside a CDC envelope containing fields such as `before`, `after`, `op`, and `source`. The sink previously lacked logic to unwrap and process the actual row state.
- **Type mismatch:** Solr expects consistent string-based values for identifiers and indexed fields, while CDC events often contain numeric types (`Integer`, `Long`), causing silent field drops during indexing.
- **Record lifecycle handling:** Conversion failures and intentionally skipped records (such as processed DELETE events) were not clearly differentiated, potentially leading to silent data loss.

Additionally, while CDC transformation can be handled externally using Pulsar Functions or intermediate processors, native support within the Solr sink simplifies standard CDC-to-search indexing pipelines.


### Modifications

#### Configuration

- Added `unwrapDebeziumRecord` configuration in `SolrSinkConfig` (default: `false`) to allow users to explicitly enable Debezium CDC payload handling.

#### SolrAbstractSink

Updated the parent sink lifecycle handling:

- Successful processing or intentionally skipped records now trigger `record.ack()`
- Processing failures now trigger `record.fail()` to support retries and DLQ handling
- Prevents silent data loss during conversion failures

#### SolrGenericRecordSink

Implemented native Debezium CDC support:

- Added `extractValueRecord()` using `getNativeObject()` for safe extraction of `KeyValue` payloads
- Added `isDebeziumEnvelope()` to identify valid Debezium CDC envelopes using `op` and state fields (`before` / `after`)
- Added `mapDebeziumPayload()` and `extractAfterRecord()` to recursively unwrap CDC payloads
- Added explicit DELETE handling:
  - Detects delete events (`after == null`)
  - Extracts primary key from `before`
  - Calls `deleteById` in Solr
- Added `normalizeValue()` to safely convert numeric values into Strings for Solr schema compatibility

#### Refactoring

- Simplified control flow using guard clauses
- Reduced nested branching for improved readability and maintainability

### Highlight of changes:

- Native Debezium CDC payload support in Solr sink
- End-to-end DELETE event propagation from PostgreSQL to Solr
- Improved data integrity through proper `ack()` / `fail()` lifecycle handling

### Verifying this change

Verified end-to-end using:

- Apache Pulsar 4.x standalone
- Debezium PostgreSQL Connector
- Solr 9.x
- PostgreSQL CDC events

Validation results:

- INSERT events correctly populate Solr documents
- UPDATE events correctly update indexed fields
- DELETE events correctly remove documents from Solr
- Numeric fields are normalized and indexed successfully

Example CDC operations validated:

- `"op":"c"` → INSERT
- `"op":"u"` → UPDATE
- `"op":"d"` → DELETE


### Tests added

- `testDebeziumUnwrapEnvelope`  
  Validates handling of standard Debezium envelope payloads

- `testDebeziumUnwrapFlatValue`  
  Ensures compatibility with non-envelope payloads

- `testDebeziumUnwrapDelete`  
  Verifies DELETE event handling and Solr deletion flow

- Updated mocks to support:
  - `KeyValue` schema handling
  - Debezium `op` field detection

- Confirmed no regression for non-CDC Pulsar topics


### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment