### PR TITLE
[fix][io] Prevent OOM in FileSource by bounding internal queues

### DIFF
--- a/file/src/main/java/org/apache/pulsar/io/file/FileSource.java
+++ b/file/src/main/java/org/apache/pulsar/io/file/FileSource.java
@@ -36,14 +36,20 @@ import org.apache.pulsar.io.core.SourceContext;
 public class FileSource extends PushSource<byte[]> {
 
     private ExecutorService executor;
-    private final BlockingQueue<File> workQueue = new LinkedBlockingQueue<>();
-    private final BlockingQueue<File> inProcess = new LinkedBlockingQueue<>();
-    private final BlockingQueue<File> recentlyProcessed = new LinkedBlockingQueue<>();
+    private BlockingQueue<File> workQueue;
+    private BlockingQueue<File> inProcess;
+    private BlockingQueue<File> recentlyProcessed;
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         FileSourceConfig fileConfig = FileSourceConfig.load(config);
         fileConfig.validate();
+
+        // Initialize bounded queues based on configuration to prevent OOM
+        int queueCapacity = fileConfig.getMaxQueueSize();
+        workQueue = new LinkedBlockingQueue<>(queueCapacity);
+        inProcess = new LinkedBlockingQueue<>(queueCapacity);
+        recentlyProcessed = new LinkedBlockingQueue<>(queueCapacity);
 
         // One extra for the File listing thread, and another for the cleanup thread
         executor = Executors.newFixedThreadPool(fileConfig.getNumWorkers() + 2);

--- a/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
+++ b/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
@@ -111,6 +111,12 @@ public class FileSourceConfig implements Serializable {
     private Integer numWorkers = 1;
 
     /**
+     * The maximum capacity of the internal queues. This provides backpressure
+     * to prevent OutOfMemoryErrors when processing is slower than file listing.
+     */
+    private Integer maxQueueSize = 1000;
+
+    /**
      * If set, do not delete but only rename file that has been processed.
      * This config only work when 'keepFile' property is false.
      */
@@ -168,6 +174,10 @@ public class FileSourceConfig implements Serializable {
 
         if (numWorkers != null && numWorkers <= 0) {
             throw new IllegalArgumentException("The property numWorkers must be greater than zero");
+        }
+
+        if (maxQueueSize != null && maxQueueSize <= 0) {
+            throw new IllegalArgumentException("The property maxQueueSize must be greater than zero");
         }
 
         if (processedFileSuffix != null && keepFile) {

--- a/file/src/test/java/org/apache/pulsar/io/file/FileSourceConfigTest.java
+++ b/file/src/test/java/org/apache/pulsar/io/file/FileSourceConfigTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.io.file;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
@@ -142,8 +144,60 @@ public class FileSourceConfigTest {
         config.validate();
     }
 
+    @Test
+    public void testDefaultMaxQueueSize() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("inputDirectory", "/tmp"); // Dummy directory just to pass basic validation
+
+        FileSourceConfig config = FileSourceConfig.load(map);
+
+        // Assert that if the user provides no value, it defaults to 1000
+        assertEquals(config.getMaxQueueSize(), Integer.valueOf(1000));
+    }
+
+    @Test
+    public void testValidMaxQueueSize() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("inputDirectory", "/tmp");
+        map.put("maxQueueSize", 5000);
+
+        FileSourceConfig config = FileSourceConfig.load(map);
+
+        // Assert that the custom value is loaded correctly
+        assertEquals(config.getMaxQueueSize(), Integer.valueOf(5000));
+
+        // Should not throw any exceptions
+        config.validate();
+    }
+
+    @Test
+    public void testInvalidMaxQueueSize() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("inputDirectory", "/tmp");
+
+        // Test 0
+        map.put("maxQueueSize", 0);
+        assertThrows(IllegalArgumentException.class, () -> {
+            FileSourceConfig config = FileSourceConfig.load(map);
+            config.validate();
+        });
+
+        // Test Negative Number
+        map.put("maxQueueSize", -5);
+        assertThrows(IllegalArgumentException.class, () -> {
+            FileSourceConfig config = FileSourceConfig.load(map);
+            config.validate();
+        });
+    }
+
     private File getFile(String name) {
         ClassLoader classLoader = getClass().getClassLoader();
-        return new File(classLoader.getResource(name).getFile());
+        try {
+            // Using .toURI() automatically decodes the %20 back into a normal space
+            return new File(classLoader.getResource(name).toURI());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse file path", e);
+        }
+
     }
 }

--- a/file/src/test/java/org/apache/pulsar/io/file/FileSourceConfigTest.java
+++ b/file/src/test/java/org/apache/pulsar/io/file/FileSourceConfigTest.java
@@ -192,12 +192,6 @@ public class FileSourceConfigTest {
 
     private File getFile(String name) {
         ClassLoader classLoader = getClass().getClassLoader();
-        try {
-            // Using .toURI() automatically decodes the %20 back into a normal space
-            return new File(classLoader.getResource(name).toURI());
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse file path", e);
-        }
-
+        return new File(classLoader.getResource(name).getFile());
     }
 }


### PR DESCRIPTION
Fixes [apache#25135](https://github.com/apache/pulsar/issues/25135)

### Motivation

The `FileSource` connector currently initializes its internal queues (`workQueue`, `inProcess`, and `recentlyProcessed`) using unbounded `LinkedBlockingQueue` instances.

Under heavy workloads, the `FileListingThread` can scan and enqueue files significantly faster than the worker threads can process them. Since the queues have no capacity limits, pending file tasks accumulate indefinitely in memory, eventually resulting in a fatal `java.lang.OutOfMemoryError`.

This creates a classic unbounded producer-consumer backpressure issue where the producer rate is unconstrained by downstream processing throughput.

The issue was reproduced locally by:

- Running the connector with a constrained JVM heap
- Generating 500,000 dummy files
- Slowing file processing relative to directory scanning

This consistently triggered heap exhaustion during file listing.


### Modifications

#### Queue Backpressure

- Added `maxQueueSize` configuration to `FileSourceConfig`
- Introduced a bounded queue capacity with a default value of `1000`
- Updated `FileSource` to initialize:
  - `workQueue`
  - `inProcess`
  - `recentlyProcessed`
  
  using bounded `LinkedBlockingQueue` instances

This ensures the file listing thread naturally blocks when downstream processing cannot keep up, preventing unbounded memory growth.

#### Configuration Validation

- Added validation to reject invalid queue sizes (`<= 0`)
- Added configuration tests to verify:
  - default values
  - custom values
  - invalid configuration handling

#### Stability Improvements

- Introduced proper backpressure behavior between:
  - `FileListingThread`
  - file processing workers

- Prevents uncontrolled queue accumulation during:
  - massive directory scans
  - slow I/O
  - large file processing workloads


### Verifying this change

Verified locally using:

- Apache Pulsar FileSource connector
- Restricted heap size (`-Xmx64m`)
- Large-scale directory generation (`500,000` files)

**Manual Verification:**

* Simulated the environment locally using the Pulsar FileSource connector with a restricted heap size (`-Xmx64m`) and a large-scale directory generation (`500,000` files).

- Before this change:
  - heap usage continuously increased
  - connector terminated with `java.lang.OutOfMemoryError`

- After this change:
  - memory usage remained stable
  - queue growth was bounded
  - file listing naturally paused under load due to backpressure


### Tests added

- Added `FileSourceConfigTest` coverage for:
  - default `maxQueueSize`
  - custom queue size configuration
  - invalid / valid values (`<= 0`)

- Confirmed existing FileSource behavior remains unchanged under normal workloads


### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment