### PR TITLE
[fix][io] Fix loading offset issues in Kafka Adaptor

### DIFF
--- a/kafka-connect-adaptor/build.gradle.kts
+++ b/kafka-connect-adaptor/build.gradle.kts
@@ -62,8 +62,17 @@ dependencies {
     testImplementation(libs.netty.reactive.streams)
 }
 
-// KCA tests depend on pulsar-broker internals that have changed since the
-// last released version. Tests will compile once matching pulsar artifacts
-// are published. Skip for now to unblock CI.
-tasks.named("compileTestJava") { enabled = false }
-tasks.named("test") { enabled = false }
+// Some KCA tests depend on pulsar-broker internals that have changed since the
+// last released version. Those tests will compile once matching pulsar artifacts
+// are published; exclude only them for now so that self-contained unit tests
+// still compile and run in CI.
+val brokerDependentTestSources = listOf(
+    "**/KafkaConnectSinkTest.java",
+    "**/KafkaConnectSourceErrRecTest.java",
+    "**/KafkaConnectSourceErrTest.java",
+    "**/KafkaConnectSourceTest.java",
+    "**/PulsarOffsetBackingStoreTest.java",
+)
+tasks.named<JavaCompile>("compileTestJava") {
+    exclude(brokerDependentTestSources)
+}

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -43,6 +43,8 @@ import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.OffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
@@ -114,6 +116,15 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         keyConverter.configure(config, true);
         valueConverter.configure(config, false);
 
+        // initialize offset converters
+        Converter offsetKeyConverter = new JsonConverter();
+        Converter offsetValueConverter = new JsonConverter();
+
+        Map<String, Object> offsetConverterConfig = new HashMap<>();
+        offsetConverterConfig.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false);
+        offsetKeyConverter.configure(offsetConverterConfig, true);
+        offsetValueConverter.configure(offsetConverterConfig, false);
+
         offsetStore = new PulsarOffsetBackingStore(sourceContext.getPulsarClient());
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(stringConfig);
         offsetStore.configure(pulsarKafkaWorkerConfig);
@@ -122,14 +133,14 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         offsetReader = new OffsetStorageReaderImpl(
                 offsetStore,
                 "pulsar-kafka-connect-adaptor",
-                keyConverter,
-                valueConverter
+                offsetKeyConverter,
+                offsetValueConverter
         );
         offsetWriter = new OffsetStorageWriter(
                 offsetStore,
                 "pulsar-kafka-connect-adaptor",
-                keyConverter,
-                valueConverter
+                offsetKeyConverter,
+                offsetValueConverter
         );
 
         sourceTaskContext = new PulsarIOSourceTaskContext(offsetReader, pulsarKafkaWorkerConfig);

--- a/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.io.kafka.connect;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
@@ -38,13 +39,13 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.source.SourceTaskContext;
-import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.OffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
@@ -117,13 +118,8 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         valueConverter.configure(config, false);
 
         // initialize offset converters
-        Converter offsetKeyConverter = new JsonConverter();
-        Converter offsetValueConverter = new JsonConverter();
-
-        Map<String, Object> offsetConverterConfig = new HashMap<>();
-        offsetConverterConfig.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false);
-        offsetKeyConverter.configure(offsetConverterConfig, true);
-        offsetValueConverter.configure(offsetConverterConfig, false);
+        Converter offsetKeyConverter = createOffsetConverter(true);
+        Converter offsetValueConverter = createOffsetConverter(false);
 
         offsetStore = new PulsarOffsetBackingStore(sourceContext.getPulsarClient());
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(stringConfig);
@@ -176,6 +172,19 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         sourceTask.initialize(sourceTaskContext);
         sourceTask.start(taskConfig);
     }
+
+    /**
+     * Creates a converter for offset (de)serialization. Offsets are always stored as schema-less
+     * JSON, independently of the converters configured for the data topics — the same hardcoded
+     * behavior as Kafka Connect's internal converters (see KIP-174).
+     */
+    @VisibleForTesting
+    static Converter createOffsetConverter(boolean isKey) {
+        Converter converter = new JsonConverter();
+        converter.configure(Map.of(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false), isKey);
+        return converter;
+    }
+
     private void onOffsetsFlushed(Throwable error, CompletableFuture<Void> snapshotFlushFuture) {
         if (error != null) {
             log.error("Failed to flush offsets to storage: ", error);

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectOffsetConverterTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectOffsetConverterTest.java
@@ -46,8 +46,8 @@ import org.testng.annotations.Test;
  *
  * <p><b>TODO:</b> These tests verify the offset converters work in isolation but don't test the
  * actual production code path - that {@link AbstractKafkaConnectSource#open} uses these JSON
- * converters for offset storage. Once pulsar-broker test artifacts are available, replace these
- * with an E2E test that: (1) initializes the adaptor with AvroConverter for data topics,
+ * converters for offset storage. Once pulsar-broker test artifacts are available, add a new
+ * E2E test that: (1) initializes the adaptor with AvroConverter for data topics,
  * (2) processes a message and stores an offset, (3) simulates a restart with fresh converter
  * instances, and (4) verifies the offset was loaded correctly. This would prove the production
  * path uses JSON converters for offsets regardless of data converter configuration.

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectOffsetConverterTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectOffsetConverterTest.java
@@ -43,6 +43,14 @@ import org.testng.annotations.Test;
  * {@link MockSchemaRegistryClient}), offsets became unreadable after a restart and connectors
  * silently lost their position. Offsets must instead use dedicated schema-less JSON converters,
  * matching Kafka Connect's internal converters.
+ *
+ * <p><b>TODO:</b> These tests verify the offset converters work in isolation but don't test the
+ * actual production code path - that {@link AbstractKafkaConnectSource#open} uses these JSON
+ * converters for offset storage. Once pulsar-broker test artifacts are available, replace these
+ * with an E2E test that: (1) initializes the adaptor with AvroConverter for data topics,
+ * (2) processes a message and stores an offset, (3) simulates a restart with fresh converter
+ * instances, and (4) verifies the offset was loaded correctly. This would prove the production
+ * path uses JSON converters for offsets regardless of data converter configuration.
  */
 public class KafkaConnectOffsetConverterTest {
 

--- a/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectOffsetConverterTest.java
+++ b/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectOffsetConverterTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kafka.connect;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import io.confluent.connect.avro.AvroConverter;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
+import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that connector offsets written before a restart can be read back after the restart.
+ *
+ * <p>The adaptor previously serialized offsets with the connector's data converters. With
+ * converters that keep out-of-band state (e.g. {@link AvroConverter} backed by an in-memory
+ * {@link MockSchemaRegistryClient}), offsets became unreadable after a restart and connectors
+ * silently lost their position. Offsets must instead use dedicated schema-less JSON converters,
+ * matching Kafka Connect's internal converters.
+ */
+public class KafkaConnectOffsetConverterTest {
+
+    private static final String NAMESPACE = "pulsar-kafka-connect-adaptor";
+    private static final Map<String, Object> PARTITION = Map.of("topic", "test-topic", "partition", 0);
+    private static final Map<String, Object> OFFSET = Map.of("position", 42L);
+
+    /** Minimal in-memory store standing in for the offset topic that survives a connector restart. */
+    private static class InMemoryOffsetBackingStore extends MemoryOffsetBackingStore {
+        @Override
+        public Set<Map<String, Object>> connectorPartitions(String connectorName) {
+            return Collections.emptySet();
+        }
+    }
+
+    private void writeOffset(MemoryOffsetBackingStore store, Converter keyConverter, Converter valueConverter)
+            throws Exception {
+        OffsetStorageWriter writer = new OffsetStorageWriter(store, NAMESPACE, keyConverter, valueConverter);
+        writer.offset(PARTITION, OFFSET);
+        assertTrue(writer.beginFlush(10, TimeUnit.SECONDS));
+        writer.doFlush((error, ignored) -> { }).get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testOffsetsSurviveRestartWithJsonOffsetConverters() throws Exception {
+        MemoryOffsetBackingStore store = new InMemoryOffsetBackingStore();
+        store.start();
+        try {
+            writeOffset(store,
+                    AbstractKafkaConnectSource.createOffsetConverter(true),
+                    AbstractKafkaConnectSource.createOffsetConverter(false));
+
+            // simulate a connector restart: fresh converter instances, same backing store
+            OffsetStorageReaderImpl reader = new OffsetStorageReaderImpl(store, NAMESPACE,
+                    AbstractKafkaConnectSource.createOffsetConverter(true),
+                    AbstractKafkaConnectSource.createOffsetConverter(false));
+
+            Map<String, Object> restored = reader.offset(PARTITION);
+            assertNotNull(restored, "offset must be readable after a restart");
+            assertEquals(((Number) restored.get("position")).longValue(), 42L);
+        } finally {
+            store.stop();
+        }
+    }
+
+    /**
+     * Documents the failure mode this fix addresses: offsets written with the Avro data
+     * converters (as the adaptor did before) are not readable after a restart, because the
+     * fresh {@link MockSchemaRegistryClient} no longer holds the writer's schemas.
+     */
+    @Test
+    public void testAvroDataConvertersLoseOffsetsAfterRestart() throws Exception {
+        Map<String, Object> avroConfig =
+                Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock");
+
+        MemoryOffsetBackingStore store = new InMemoryOffsetBackingStore();
+        store.start();
+        try {
+            Converter oldKeyConverter = new AvroConverter(new MockSchemaRegistryClient());
+            oldKeyConverter.configure(avroConfig, true);
+            Converter oldValueConverter = new AvroConverter(new MockSchemaRegistryClient());
+            oldValueConverter.configure(avroConfig, false);
+            writeOffset(store, oldKeyConverter, oldValueConverter);
+
+            // simulate a connector restart: the new mock schema registries are empty
+            Converter newKeyConverter = new AvroConverter(new MockSchemaRegistryClient());
+            newKeyConverter.configure(avroConfig, true);
+            Converter newValueConverter = new AvroConverter(new MockSchemaRegistryClient());
+            newValueConverter.configure(avroConfig, false);
+            OffsetStorageReaderImpl reader = new OffsetStorageReaderImpl(store, NAMESPACE,
+                    newKeyConverter, newValueConverter);
+
+            Map<String, Object> restored;
+            try {
+                restored = reader.offset(PARTITION);
+            } catch (Exception e) {
+                // reading failed outright — the offset is lost, which is the bug
+                return;
+            }
+            assertNull(restored, "expected the offset written by the data converters to be lost after restart");
+        } finally {
+            store.stop();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #30

Pulsar Kafka Connect adaptor previously used the same converters for both data and offset storage. This could cause various issues. For example when data were using AvroConverter, offsets were serialized using MockSchemaRegistryClient (in memory only). After a connector restart, the fresh MockSchemaRegistryClient had no schema records, causing deserialization to fail with "Subject Not Found; error code: 40401" and the connector losing its offset position.

Kafka Connect do not reuse the data converters for offset, but creates new JSON converters configured with `schema.enable` set to `false`. Thus the adaptor was changed to have the same behavior.

This is a breaking change for connectors that previously stored offsets in a non-JSON format, those offsets do not have to be readable after upgrade. The offsets probably weren't readable even before this fix (as we can see for the Avro converter). But since we cannot be sure what converters users used and how they behaved, this change should be probably included in a major release.

Note: The tests for adaptor currently do not compile. We are waiting for matching pulsar artifact to be published. The fix was verified E2E by manual testing.

## Upgrade Notes

**Breaking Change: Offset Format**

This fix changes how the Kafka Connect Adaptor stores connector offsets. After upgrading, connectors may lose their stored offsets and restart from the beginning (or another position depending on the connector's configuration for missing offsets).

**Who is affected:**
- **Connectors using converters that were not already storing offsets as schema-less JSON** will restart from the beginning after upgrade. Most notably `JsonConverter` with `schemas.enable=true` (the JsonConverter default) - these offsets were working before but will be lost on upgrade
- **Note:** `AvroConverter` and potentially other schema-aware converters were already broken before this fix - offsets were lost on every restart. For these connectors, this is the last such restart. After upgrading, offsets will persist correctly across subsequent restarts.

**What happens:**
Before this fix, the adaptor used the connector's data converters for offsets too. After
upgrade, offsets are always stored as schema-less JSON (matching Kafka Connect's internal
converters). Offset lookups happen by serialized key: the partition key is serialized with the
key converter and matched against the stored records; only on a match is the value deserialized.

The exact symptom therefore depends on the previous key/value converter combination:
- If the previous **key** converter produced a different serialized format (e.g. `AvroConverter`,
or `JsonConverter` with `schemas.enable=true`), the re-serialized lookup key no longer matches
the stored key, the lookup returns null, and the connector silently restarts from the beginning
with no error in the logs.
- If the key still matches but the previous **value** converter's records can't be deserialized
under the new converter, it surfaces as an explicit error instead (e.g. `AvroConverter`'s
"Subject Not Found" against a fresh in-memory schema registry).

**Mitigation:**
  - For connectors that can safely reprocess: accept the one-time restart from the beginning.
  - For connectors with critical offset state: before starting the upgraded connector, pre-populate
    the offset topic with the current position encoded in the new schema-less JSON format, so the
    connector picks it up on first start instead of restarting from the beginning.