### PR TITLE
[fix][ci] Update setup-gradle action to v6.2.0 to match ASF actions allowlist

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Setup Gradle with Develocity
       if: ${{ inputs.develocity-access-key != '' && inputs.build-scan-publish == 'true' }}
-      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         develocity-injection-enabled: true
         develocity-url: https://develocity.apache.org
@@ -62,7 +62,7 @@ runs:
 
     - name: Setup Gradle
       if: ${{ !(inputs.develocity-access-key != '' && inputs.build-scan-publish == 'true') }}
-      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         build-scan-publish: ${{ inputs.build-scan-publish }}
         build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'


### PR DESCRIPTION
### Motivation

All CI runs in this repository currently fail at the "Setup Gradle" step with:

```
Error: The action gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f is not allowed in apache/pulsar-connectors because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ...
```

The pinned SHA (v6.0.1) was removed from the ASF GitHub Actions allowlist, so every workflow that uses the `.github/actions/setup-gradle` composite action fails before any build step runs (see e.g. the run on #31: https://github.com/apache/pulsar-connectors/actions/runs/28885273489).

This is the same breakage already fixed in apache/pulsar by apache/pulsar#26156 — this repository carries its own copy of the composite action, which was still pinned to the revoked SHA.

### Modifications

Bump both `gradle/actions/setup-gradle` pins in `.github/actions/setup-gradle/action.yml` from `39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f` (v6.0.1) to `3f131e8634966bd73d06cc69884922b02e6faf92` (v6.2.0), which matches the current ASF allowlist (`approved_patterns.yml` in infrastructure-actions-allow-list) — verified by the merged apache/pulsar fix passing CI with this SHA.

### Verification

CI on this PR itself demonstrates the fix: the "Build and License check" job gets past the Setup Gradle step again.

### Documentation

- [x] `doc-not-needed`