### PR TITLE
[fix][ci] Fix Tune Runner VM failure when no sd* block devices exist

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -53,8 +53,10 @@ runs:
             fi
             # disable discard/trim at device level since remount with nodiscard doesn't seem to be effective
             # https://www.spinics.net/lists/linux-ide/msg52562.html
-            for i in /sys/block/sd*/queue/discard_max_bytes; do
-              echo 0 | sudo tee $i
+            for i in /sys/block/*/queue/discard_max_bytes; do
+              if [ -f "$i" ]; then
+                echo 0 | sudo tee "$i"
+              fi
             done
             # disable unnecessary timers
             sudo systemctl stop fstrim.timer fstrim.service \


### PR DESCRIPTION
### Motivation

After #37 unblocked the setup-gradle step, PR #31's CI surfaced the next infrastructure failure: the `Tune Runner VM` step fails on current GitHub runner images with

```
tee: '/sys/block/sd*/queue/discard_max_bytes': No such file or directory
Error: Process completed with exit code 1.
```

The runner images no longer expose `sd*` block devices, so the glob stays unexpanded, `tee` exits 1, and the composite action's `bash -e` shell aborts the job before tests run. See failing run: https://github.com/apache/pulsar-connectors/actions/runs/29036158474

### Modifications

Sync the fix already applied in apache/pulsar master's `tune-runner-vm` action: glob all block devices (`/sys/block/*/queue/discard_max_bytes`) and guard each entry with a file-existence check.