### PR TITLE
[improve][test] Add Debezium Oracle source integration test

### DIFF
--- a/debezium/oracle/build.gradle.kts
+++ b/debezium/oracle/build.gradle.kts
@@ -25,4 +25,8 @@ dependencies {
     implementation(libs.pulsar.io.core)
     implementation(project(":debezium:pulsar-io-debezium-core"))
     implementation(libs.debezium.connector.oracle)
+
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.pulsar)
+    testImplementation(libs.pulsar.client)
 }

--- a/debezium/oracle/src/test/java/org/apache/pulsar/io/debezium/oracle/DebeziumOracleSourceTest.java
+++ b/debezium/oracle/src/test/java/org/apache/pulsar/io/debezium/oracle/DebeziumOracleSourceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.debezium.oracle;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+import org.awaitility.Awaitility;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class DebeziumOracleSourceTest {
+
+    private static final String PULSAR_IMAGE =
+            System.getenv().getOrDefault("PULSAR_TEST_IMAGE", "apachepulsar/pulsar:4.1.3");
+
+    private static final String ORACLE_IMAGE = "gvenzl/oracle-free:23-slim-faststart";
+
+    private static final int ORACLE_PORT = 1521;
+
+    private GenericContainer<?> oracleContainer;
+    private PulsarContainer pulsarContainer;
+    private PulsarClient pulsarClient;
+    private DebeziumOracleSource source;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        // Use GenericContainer instead of the testcontainers oracle-free module:
+        // debezium-bom 3.4.x pins testcontainers core to 2.x, which is binary
+        // incompatible with the 1.x oracle-free module (and no 2.x release of it
+        // exists yet).
+        // All of the Oracle-side preparation (archive log mode, supplemental logging,
+        // the c##dbzuser LogMiner user and the seeded DEBEZIUM.PRODUCTS test table)
+        // is performed by the init script below, which the gvenzl image executes as
+        // SYSDBA on first startup, before it prints "DATABASE IS READY TO USE!".
+        oracleContainer = new GenericContainer<>(DockerImageName.parse(ORACLE_IMAGE))
+                .withExposedPorts(ORACLE_PORT)
+                .withEnv("ORACLE_PASSWORD", "top_secret")
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource("debezium-oracle-setup.sql"),
+                        "/container-entrypoint-initdb.d/01-debezium-setup.sql")
+                // The init script restarts the database to enable archive log mode,
+                // so allow a generous startup timeout.
+                .waitingFor(Wait.forLogMessage(".*DATABASE IS READY TO USE!.*\\s", 1)
+                        .withStartupTimeout(Duration.ofMinutes(6)));
+        oracleContainer.start();
+
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE));
+        pulsarContainer.start();
+
+        pulsarClient = PulsarClient.builder()
+                .serviceUrl(pulsarContainer.getPulsarBrokerUrl())
+                .build();
+
+        source = new DebeziumOracleSource();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() throws Exception {
+        if (source != null) {
+            try {
+                source.close();
+            } catch (Exception e) {
+                log.warn("Failed to close source", e);
+            }
+        }
+        if (pulsarClient != null) {
+            pulsarClient.close();
+        }
+        if (pulsarContainer != null) {
+            pulsarContainer.stop();
+        }
+        if (oracleContainer != null) {
+            oracleContainer.stop();
+        }
+    }
+
+    @Test(timeOut = 600_000)
+    public void testOracleCdcEvents() throws Exception {
+        String pulsarServiceUrl = pulsarContainer.getPulsarBrokerUrl();
+
+        SourceContext sourceContext = mock(SourceContext.class);
+        when(sourceContext.getPulsarClient()).thenReturn(pulsarClient);
+        when(sourceContext.getPulsarClientBuilder()).thenReturn(
+                PulsarClient.builder().serviceUrl(pulsarServiceUrl));
+        when(sourceContext.getTenant()).thenReturn("public");
+        when(sourceContext.getNamespace()).thenReturn("default");
+        when(sourceContext.getSourceName()).thenReturn("debezium-oracle-test");
+        when(sourceContext.getSecret(anyString())).thenReturn(null);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("database.hostname", oracleContainer.getHost());
+        config.put("database.port", String.valueOf(oracleContainer.getMappedPort(ORACLE_PORT)));
+        config.put("database.user", "c##dbzuser");
+        config.put("database.password", "dbz");
+        config.put("database.dbname", "FREE");
+        config.put("database.pdb.name", "FREEPDB1");
+        config.put("topic.prefix", "oracle1");
+        config.put("table.include.list", "DEBEZIUM.PRODUCTS");
+        config.put("include.schema.changes", "false");
+        // Read the data dictionary from the online catalog instead of mining it
+        // from the redo logs; this keeps connector startup lightweight for tests.
+        config.put("log.mining.strategy", "online_catalog");
+        config.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
+
+        source.open(config, sourceContext);
+
+        // Debezium performs an initial snapshot of existing data.
+        // We should receive CDC records for the 2 rows seeded by the init script.
+        Awaitility.await()
+                .atMost(5, TimeUnit.MINUTES)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    int recordCount = 0;
+                    Record<KeyValue<byte[], byte[]>> record;
+                    while ((record = source.read()) != null) {
+                        assertNotNull(record.getValue());
+                        log.info("Received CDC record: key={}", record.getKey().orElse(null));
+                        recordCount++;
+                        record.ack();
+                        if (recordCount >= 2) {
+                            break;
+                        }
+                    }
+                    assertTrue(recordCount >= 2,
+                            "Expected at least 2 CDC records from initial snapshot, got " + recordCount);
+                });
+    }
+}

--- a/debezium/oracle/src/test/resources/debezium-oracle-setup.sql
+++ b/debezium/oracle/src/test/resources/debezium-oracle-setup.sql
@@ -1,0 +1,103 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Prepares an Oracle Database Free (gvenzl/oracle-free) container for
+-- Debezium LogMiner-based CDC. Executed once as SYSDBA from
+-- /container-entrypoint-initdb.d/ on first container startup.
+-- Based on the canonical Debezium Oracle connector setup:
+-- https://debezium.io/documentation/reference/stable/connectors/oracle.html
+
+-- 1) Enable archive log mode (required by the LogMiner adapter).
+ALTER SYSTEM SET db_recovery_file_dest_size = 5G;
+ALTER SYSTEM SET db_recovery_file_dest = '/opt/oracle/oradata' SCOPE=spfile;
+SHUTDOWN IMMEDIATE
+STARTUP MOUNT
+ALTER DATABASE ARCHIVELOG;
+ALTER DATABASE OPEN;
+ALTER PLUGGABLE DATABASE ALL OPEN;
+
+-- 2) Enable minimal supplemental logging at the CDB level.
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
+
+-- 3) Tablespaces for the LogMiner user (CDB and PDB).
+CREATE TABLESPACE LOGMINER_TBS DATAFILE '/opt/oracle/oradata/FREE/logminer_tbs.dbf'
+    SIZE 25M REUSE AUTOEXTEND ON MAXSIZE UNLIMITED;
+
+ALTER SESSION SET CONTAINER=FREEPDB1;
+
+CREATE TABLESPACE LOGMINER_TBS DATAFILE '/opt/oracle/oradata/FREE/FREEPDB1/logminer_tbs.dbf'
+    SIZE 25M REUSE AUTOEXTEND ON MAXSIZE UNLIMITED;
+
+ALTER SESSION SET CONTAINER=CDB$ROOT;
+
+-- 4) Common (CDB-wide) Debezium connector user with the LogMiner grant set.
+CREATE USER c##dbzuser IDENTIFIED BY dbz
+    DEFAULT TABLESPACE LOGMINER_TBS
+    QUOTA UNLIMITED ON LOGMINER_TBS
+    CONTAINER=ALL;
+
+GRANT CREATE SESSION TO c##dbzuser CONTAINER=ALL;
+GRANT SET CONTAINER TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$DATABASE TO c##dbzuser CONTAINER=ALL;
+GRANT FLASHBACK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TRANSACTION TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY DICTIONARY TO c##dbzuser CONTAINER=ALL;
+GRANT LOGMINING TO c##dbzuser CONTAINER=ALL;
+GRANT CREATE TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT LOCK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT ALTER ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT CREATE SEQUENCE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR_D TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG_HISTORY TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_LOGS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_CONTENTS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_PARAMETERS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGFILE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVED_LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$TRANSACTION TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$MYSTAT TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$STATNAME TO c##dbzuser CONTAINER=ALL;
+
+-- 5) Test schema: a table with two seeded rows in the FREEPDB1 PDB.
+ALTER SESSION SET CONTAINER=FREEPDB1;
+
+CREATE USER debezium IDENTIFIED BY dbz
+    DEFAULT TABLESPACE LOGMINER_TBS
+    QUOTA UNLIMITED ON LOGMINER_TBS;
+
+GRANT CONNECT TO debezium;
+GRANT CREATE SESSION TO debezium;
+GRANT CREATE TABLE TO debezium;
+GRANT CREATE SEQUENCE TO debezium;
+
+CREATE TABLE debezium.products (
+    id NUMBER(9,0) NOT NULL PRIMARY KEY,
+    name VARCHAR2(255) NOT NULL,
+    description VARCHAR2(512)
+);
+
+INSERT INTO debezium.products VALUES (1, 'widget', 'A small widget');
+INSERT INTO debezium.products VALUES (2, 'gadget', 'A fancy gadget');
+COMMIT;
+
+ALTER TABLE debezium.products ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;


### PR DESCRIPTION
Fixes #44

### Motivation

The `debezium/oracle` module (`DebeziumOracleSource`) had no tests. This PR adds a Testcontainers integration test that exercises the connector end-to-end against a real Oracle database, mirroring the shape of the existing `DebeziumMysqlSourceTest`.

Oracle is the heaviest Debezium variant to test: LogMiner-based CDC requires archive log mode, supplemental logging, a common (CDB-wide) user with an extensive grant set, and PDB-aware connector configuration. All of that is handled inside the test via a container init script.

### Modifications

- New `DebeziumOracleSourceTest` in `debezium/oracle`:
  - Starts `gvenzl/oracle-free:23-slim-faststart` (the image family Debezium's own test infrastructure uses) plus a `PulsarContainer` for the schema-history topic.
  - A SYSDBA init script (`src/test/resources/debezium-oracle-setup.sql`, copied to `/container-entrypoint-initdb.d/`) enables archive log mode (`SHUTDOWN IMMEDIATE` / `STARTUP MOUNT` / `ALTER DATABASE ARCHIVELOG`), enables minimal supplemental logging, creates `LOGMINER_TBS` tablespaces in CDB and PDB, creates `c##dbzuser` with the LogMiner grant set from the Debezium 3.x documentation, and seeds a `DEBEZIUM.PRODUCTS` table (2 rows) in `FREEPDB1` with `SUPPLEMENTAL LOG DATA (ALL) COLUMNS`. The gvenzl entrypoint runs init scripts before printing `DATABASE IS READY TO USE!`, so the container wait strategy also covers the DB restart.
  - Opens `DebeziumOracleSource` with `database.dbname=FREE`, `database.pdb.name=FREEPDB1`, `table.include.list=DEBEZIUM.PRODUCTS`, `log.mining.strategy=online_catalog`, and a Pulsar-backed schema history, then asserts the initial snapshot emits at least 2 records.
- `debezium/oracle/build.gradle.kts`: adds `testcontainers`, `testcontainers-pulsar`, and `pulsar-client` test dependencies.

Notes on two dependency findings:

- **Oracle JDBC driver**: no extra test-scoped driver is needed. `io.debezium:debezium-connector-oracle:3.4.2.Final` pulls `com.oracle.database.jdbc:ojdbc11:21.15.0.0` (plus `orai18n`/`xdb`/`xmlparserv2`) transitively onto the runtime classpath, so the driver also ends up in the NAR. No runtime-driver gap in this module as built today.
- **Why `GenericContainer` instead of `org.testcontainers.oracle.OracleContainer`**: `debezium-bom:3.4.2.Final` constrains Testcontainers core to 2.0.2, while the `org.testcontainers:oracle-free` module only exists up to 1.21.4 and references shaded classes removed in core 2.x (`NoClassDefFoundError: org.testcontainers.shaded.org.apache.commons.lang3.StringUtils` at `OracleContainer.withPassword`). Using `GenericContainer` against core 2.0.2 avoids the mixed-version breakage and matches the approach already used by `DebeziumMysqlSourceTest`.

### Verifying this change

Run locally (Docker required):

```
./gradlew :debezium:pulsar-io-debezium-oracle:test
```

Local result (macOS/arm64, Docker Desktop): **PASSED** in ~37s once the image was pulled; the test received snapshot records with keys `{"ID":1}` and `{"ID":2}`. The init script was additionally verified standalone: `V$DATABASE.LOG_MODE=ARCHIVELOG`, `SUPPLEMENTAL_LOG_DATA_MIN=YES`, `c##dbzuser` can connect to `FREEPDB1` and sees the 2 seeded rows, and the container logs contain no `ORA-`/`SP2-` errors. `:debezium:pulsar-io-debezium-oracle:check` (spotless/checkstyle) passes.

CI-runner risk worth calling out explicitly: the `gvenzl/oracle-free:23-slim-faststart` image is large (~1.6 GB) and Oracle Free wants ~2 GB of memory; the init script also restarts the database once to enable archive log mode. Startup on a standard GitHub-hosted runner will be minutes, not seconds — the test uses a 6-minute container startup timeout, a 5-minute Awaitility window for the snapshot, and a 10-minute overall test timeout. If the runner is memory-constrained alongside other container tests, this test will be the first to feel it.
