### PR TITLE
[improve][io] Upgrade Debezium to 3.4.3.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,7 +169,7 @@ kafka-client = "4.1.1"
 confluent = "8.1.1"
 opensearch = "2.19.4"
 elasticsearch-java = "8.15.3"
-debezium = "3.4.2.Final"
+debezium = "3.4.3.Final"
 kubernetesclient = "23.0.0"
 # IO connector specific
 aerospike-client = "4.5.0"


### PR DESCRIPTION
### Motivation

The repository pins `debezium = "3.4.2.Final"` (released 2026-03-02). `3.4.3.Final` (2026-03-30) is the final patch release of the 3.4 line and carries bug fixes for the exact code we run, but was never picked up.

This is the low-risk half of the version story. The larger migration to `3.6.0.Final` — Debezium is now two minor versions ahead of us, and there is no LTS line — is tracked separately in #63.

### Modifications

Bump `debezium` in `gradle/libs.versions.toml` from `3.4.2.Final` to `3.4.3.Final`. A patch release within the same minor line: no API changes, no configuration changes, no connector-set changes.

### Verifying this change

Ran the full Debezium test suite locally against the new version — including the MySQL and Postgres CDC integration tests, which exercise real databases and Pulsar via Testcontainers:

```
DebeziumMysqlSourceTest > testMysqlCdcEvents PASSED
DebeziumPostgresSourceTest > testPostgresCdcEvents PASSED
PulsarSchemaHistoryTest > shouldStartWithEmptyTopicAndStoreDataAndRecoverAllState PASSED
PulsarSchemaHistoryTest > shouldIgnoreUnparseableMessages PASSED
PulsarSchemaHistoryTest > shouldStopOnUnparseableSQL PASSED
PulsarSchemaHistoryTest > testExists PASSED
PulsarSchemaHistoryTest > testSubscriptionName PASSED
BUILD SUCCESSFUL in 1m 26s
```

Coverage here will get considerably stronger once #58 (MongoDB), #60 (SQL Server), and #62 (Oracle) merge — those add real-database tests for the three remaining Debezium source connectors, which is the safety net #63 will need.