### PR TITLE
[doc][io] List the Debezium MariaDB source in the README connector table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ mounting them into the `apachepulsar/pulsar` Docker image.
 | Connector | Description |
 |-----------|-------------|
 | Canal | MySQL binlog via Alibaba Canal |
-| Debezium (MySQL, PostgreSQL, MongoDB, MSSQL, Oracle) | CDC via Debezium |
+| Debezium (MySQL, MariaDB, PostgreSQL, MongoDB, MSSQL, Oracle) | CDC via Debezium |
 | DynamoDB | Amazon DynamoDB Streams |
 | File | Local filesystem |
 | Kafka | Apache Kafka |


### PR DESCRIPTION
### Motivation

#69 added the Debezium MariaDB source connector, but the README's Sources table still reads `Debezium (MySQL, PostgreSQL, MongoDB, MSSQL, Oracle)` — the documentation commit did not make it into the merged change.

### Modifications

Add MariaDB to the Debezium row of the Sources table.

Note that the repo's other doc surfaces were already covered by #69: the sample source config (`debezium-mariadb-source-config.yaml`) ships with the module, and the module is wired into `docs/build.gradle.kts`. `ConnectorDocGenerator` only emits pages for `@Connector`-annotated classes, which no Debezium module uses, so no generated page is expected for MariaDB — same as for its five siblings.