### PR TITLE
[improve][test] Add InfluxDB v1 and v2 sink integration tests, deflake the v2 mock test

### DIFF
--- a/influxdb/build.gradle.kts
+++ b/influxdb/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     implementation(libs.avro)
     implementation(libs.commons.lang3)
     implementation(libs.commons.collections4)
+
+    testImplementation(libs.testcontainers)
 }

--- a/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkIntegrationTest.java
+++ b/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkIntegrationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb.v1;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
+import org.awaitility.Awaitility;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.mockito.Mockito;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Integration test for the InfluxDB v1 sink, exercised against a real InfluxDB 1.x server via
+ * Testcontainers.
+ *
+ * <p>The v1 sink is a separate code path from v2: it uses the {@code org.influxdb} client, the
+ * line-protocol {@code BatchPoints} API, and a database/retention-policy model rather than v2's
+ * org/bucket/token model. {@link InfluxDBGenericRecordSinkTest} covers it only against a mocked
+ * {@link InfluxDB}, so nothing verifies that InfluxDB accepts the points the sink builds. This
+ * test writes through the real client and reads the data back.
+ *
+ * <p>Authentication is enabled on the container so the {@code enableAuth} branch of
+ * {@link InfluxDBBuilderImpl} is exercised too.
+ */
+@Slf4j
+public class InfluxDBGenericRecordSinkIntegrationTest {
+
+    private static final DockerImageName INFLUXDB_IMAGE = DockerImageName.parse("influxdb:1.8");
+
+    private static final int INFLUXDB_PORT = 8086;
+    private static final String DATABASE = "test_db";
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "adminpassword";
+
+    /** The sink flushes asynchronously once this many records are queued. */
+    private static final int BATCH_SIZE = 2;
+
+    private GenericContainer<?> influxdbContainer;
+    private InfluxDB queryClient;
+    private InfluxDBAbstractSink<GenericRecord> sink;
+    private String influxdbUrl;
+
+    /** Fields other than {@code measurement} and {@code tags} become InfluxDB fields. */
+    @Data
+    public static class Cpu {
+        private String measurement;
+        private String model;
+        private int value;
+        private Map<String, String> tags;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp() {
+        influxdbContainer = new GenericContainer<>(INFLUXDB_IMAGE)
+                .withExposedPorts(INFLUXDB_PORT)
+                .withEnv("INFLUXDB_DB", DATABASE)
+                .withEnv("INFLUXDB_ADMIN_USER", USERNAME)
+                .withEnv("INFLUXDB_ADMIN_PASSWORD", PASSWORD)
+                .withEnv("INFLUXDB_HTTP_AUTH_ENABLED", "true")
+                .waitingFor(Wait.forHttp("/ping").forPort(INFLUXDB_PORT).forStatusCode(204));
+        influxdbContainer.start();
+
+        influxdbUrl = "http://" + influxdbContainer.getHost() + ":"
+                + influxdbContainer.getMappedPort(INFLUXDB_PORT);
+        queryClient = InfluxDBFactory.connect(influxdbUrl, USERNAME, PASSWORD);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (sink != null) {
+            sink.close();
+        }
+        if (queryClient != null) {
+            queryClient.close();
+        }
+        if (influxdbContainer != null) {
+            influxdbContainer.stop();
+        }
+    }
+
+    @Test(timeOut = 300_000)
+    public void testWritesReachInfluxDb() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("influxdbUrl", influxdbUrl);
+        config.put("username", USERNAME);
+        config.put("password", PASSWORD);
+        config.put("database", DATABASE);
+        config.put("consistencyLevel", "ONE");
+        config.put("logLevel", "NONE");
+        config.put("retentionPolicy", "autogen");
+        config.put("gzipEnable", false);
+        // Large enough that the timer does not flush for us: the batch-size path must.
+        config.put("batchTimeMs", 60_000);
+        config.put("batchSize", BATCH_SIZE);
+
+        sink = new InfluxDBGenericRecordSink();
+        sink.open(config, null);
+
+        sink.write(cpuRecord("server-1", "us-west", 10));
+        sink.write(cpuRecord("server-2", "us-east", 20));
+
+        // The sink flushes on a background executor once batchSize records are queued, so poll
+        // rather than assuming the write has landed by the time we query.
+        List<List<Object>> rows = Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .until(this::queryCpuRows, found -> found.size() >= 2);
+
+        assertEquals(rows.size(), 2, "both points should have been written");
+
+        QueryResult.Series series = cpuSeries();
+        assertNotNull(series, "the cpu measurement should exist");
+        int hostIdx = series.getColumns().indexOf("host");
+        int valueIdx = series.getColumns().indexOf("value");
+        int modelIdx = series.getColumns().indexOf("model");
+        int timeIdx = series.getColumns().indexOf("time");
+
+        List<Object> serverOne = rows.stream()
+                .filter(r -> "server-1".equals(r.get(hostIdx)))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no row for host=server-1"));
+        assertEquals(((Number) serverOne.get(valueIdx)).longValue(), 10L);
+        assertEquals(serverOne.get(modelIdx), "lenovo");
+        assertNotNull(serverOne.get(timeIdx), "timestamp should have been persisted");
+    }
+
+    private QueryResult.Series cpuSeries() {
+        QueryResult result = queryClient.query(new Query("SELECT * FROM cpu", DATABASE));
+        if (result.getResults() == null || result.getResults().get(0).getSeries() == null) {
+            return null;
+        }
+        return result.getResults().get(0).getSeries().get(0);
+    }
+
+    private List<List<Object>> queryCpuRows() {
+        QueryResult.Series series = cpuSeries();
+        return series == null ? List.of() : series.getValues();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Record<GenericRecord> cpuRecord(String host, String region, int value) {
+        Cpu cpu = new Cpu();
+        cpu.setMeasurement("cpu");
+        cpu.setModel("lenovo");
+        cpu.setValue(value);
+        cpu.setTags(Map.of("host", host, "region", region));
+
+        AvroSchema<Cpu> schema = AvroSchema.of(Cpu.class);
+        GenericSchema<GenericRecord> genericSchema = GenericSchemaImpl.of(schema.getSchemaInfo());
+
+        Message<GenericRecord> message = Mockito.mock(MessageImpl.class);
+        Mockito.when(message.getValue()).thenReturn(genericSchema.decode(schema.encode(cpu)));
+
+        return PulsarRecord.<GenericRecord>builder()
+                .message(message)
+                .topicName("influx_cpu")
+                .build();
+    }
+}

--- a/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkIntegrationTest.java
+++ b/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkIntegrationTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.influxdb.v2;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
+import org.awaitility.Awaitility;
+import org.mockito.Mockito;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Integration test for the InfluxDB v2 sink, exercised against a real InfluxDB server via
+ * Testcontainers.
+ *
+ * <p>The existing {@link InfluxDBSinkTest} verifies only that the sink calls
+ * {@code WriteApiBlocking.writePoints()} on a mock. That leaves the parts most likely to break
+ * untested: whether the points the sink builds are actually accepted by InfluxDB, and whether the
+ * measurement, tags, fields and timestamp survive the round trip. This test writes through the
+ * real client and reads the data back with Flux.
+ */
+@Slf4j
+public class InfluxDBSinkIntegrationTest {
+
+    private static final DockerImageName INFLUXDB_IMAGE = DockerImageName.parse("influxdb:2.7");
+
+    private static final int INFLUXDB_PORT = 8086;
+    private static final String ORG = "example-org";
+    private static final String BUCKET = "example-bucket";
+    private static final String TOKEN = "test-token-0123456789";
+
+    /** The sink flushes asynchronously once this many records are queued. */
+    private static final int BATCH_SIZE = 2;
+
+    private GenericContainer<?> influxdbContainer;
+    private InfluxDBClient queryClient;
+    private InfluxDBSink sink;
+    private String influxdbUrl;
+
+    /** Mirrors the POJO used by the mock-based test, so both cover the same record shape. */
+    @Data
+    public static class Cpu {
+        private String measurement;
+        private long timestamp;
+        private Map<String, String> tags;
+
+        @org.apache.avro.reflect.AvroSchema("{\"type\": \"map\", \"values\": "
+                + "[\"string\", \"int\", \"bytes\", \"long\",\"float\", \"double\", \"boolean\"]}")
+        private Map<String, Object> fields;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp() {
+        influxdbContainer = new GenericContainer<>(INFLUXDB_IMAGE)
+                .withExposedPorts(INFLUXDB_PORT)
+                .withEnv("DOCKER_INFLUXDB_INIT_MODE", "setup")
+                .withEnv("DOCKER_INFLUXDB_INIT_USERNAME", "admin")
+                .withEnv("DOCKER_INFLUXDB_INIT_PASSWORD", "adminpassword")
+                .withEnv("DOCKER_INFLUXDB_INIT_ORG", ORG)
+                .withEnv("DOCKER_INFLUXDB_INIT_BUCKET", BUCKET)
+                .withEnv("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", TOKEN)
+                .waitingFor(Wait.forHttp("/health").forPort(INFLUXDB_PORT).forStatusCode(200));
+        influxdbContainer.start();
+
+        influxdbUrl = "http://" + influxdbContainer.getHost() + ":"
+                + influxdbContainer.getMappedPort(INFLUXDB_PORT);
+        queryClient = InfluxDBClientFactory.create(influxdbUrl, TOKEN.toCharArray(), ORG);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (sink != null) {
+            sink.close();
+        }
+        if (queryClient != null) {
+            queryClient.close();
+        }
+        if (influxdbContainer != null) {
+            influxdbContainer.stop();
+        }
+    }
+
+    @Test(timeOut = 300_000)
+    public void testWritesReachInfluxDb() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("influxdbUrl", influxdbUrl);
+        config.put("token", TOKEN);
+        config.put("organization", ORG);
+        config.put("bucket", BUCKET);
+        config.put("precision", "ns");
+        config.put("logLevel", "NONE");
+        config.put("gzipEnable", false);
+        // Large enough that the timer does not flush for us: the batch-size path must.
+        config.put("batchTimeMs", 60_000);
+        config.put("batchSize", BATCH_SIZE);
+
+        sink = new InfluxDBSink();
+        sink.open(config, null);
+
+        long baseTimestamp = Instant.now().toEpochMilli() * 1_000_000L;
+        sink.write(cpuRecord("server-1", "us-west", 10, baseTimestamp));
+        sink.write(cpuRecord("server-2", "us-east", 20, baseTimestamp + 1));
+
+        // The sink flushes on a background executor once batchSize records are queued, so poll
+        // rather than assuming the write has landed by the time we query.
+        List<FluxRecord> records = Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .until(this::queryCpuRecords, found -> found.size() >= 2);
+
+        assertEquals(records.size(), 2, "both points should have been written");
+
+        FluxRecord first = records.stream()
+                .filter(r -> "server-1".equals(r.getValueByKey("host")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no record for host=server-1"));
+        assertEquals(first.getMeasurement(), "cpu");
+        assertEquals(first.getValueByKey("region"), "us-west");
+        assertEquals(((Number) first.getValue()).longValue(), 10L);
+        assertNotNull(first.getTime(), "timestamp should have been persisted");
+    }
+
+    /** Reads back the {@code value} field of the {@code cpu} measurement. */
+    private List<FluxRecord> queryCpuRecords() {
+        String flux = "from(bucket: \"" + BUCKET + "\") "
+                + "|> range(start: -1h) "
+                + "|> filter(fn: (r) => r._measurement == \"cpu\") "
+                + "|> filter(fn: (r) => r._field == \"value\")";
+        List<FluxTable> tables = queryClient.getQueryApi().query(flux, ORG);
+        return tables.stream().flatMap(t -> t.getRecords().stream()).toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Record<GenericRecord> cpuRecord(String host, String region, int value, long timestamp) {
+        Cpu cpu = new Cpu();
+        cpu.setMeasurement("cpu");
+        cpu.setTimestamp(timestamp);
+        cpu.setTags(Map.of("host", host, "region", region));
+        cpu.setFields(Map.of("value", value, "model", "lenovo"));
+
+        JSONSchema<Cpu> schema = JSONSchema.of(Cpu.class);
+        GenericSchema<GenericRecord> genericSchema = GenericSchemaImpl.of(schema.getSchemaInfo());
+
+        Message<GenericRecord> message = Mockito.mock(MessageImpl.class);
+        Mockito.when(message.getValue()).thenReturn(genericSchema.decode(schema.encode(cpu)));
+
+        return PulsarRecord.<GenericRecord>builder()
+                .message(message)
+                .topicName("influx_cpu")
+                .build();
+    }
+}

--- a/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkTest.java
+++ b/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkTest.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.Data;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Message;
@@ -49,6 +50,7 @@ import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
+import org.awaitility.Awaitility;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -179,8 +181,11 @@ public class InfluxDBSinkTest {
         influxSink.write(record);
         verify(writeApi, times(0)).writePoints(anyList());
         influxSink.write(record);
-        Thread.sleep(100);
-        verify(writeApi, times(1)).writePoints(anyList());
+        // The sink flushes on a background executor once batchSize records are queued; waiting a
+        // fixed 100ms raced with it and failed intermittently under CI load.
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(writeApi, times(1)).writePoints(anyList()));
 
         ArgumentCaptor<List<Point>> captor = ArgumentCaptor.forClass(List.class);
         verify(writeApi).writePoints(captor.capture());


### PR DESCRIPTION
Fixes #53

### Motivation

The `influxdb` module has no integration coverage. Its tests verify only that the sinks call the client on a **mock**, which leaves the parts most likely to break untested: whether InfluxDB actually accepts the points each sink builds, and whether the measurement, tags, fields, and timestamp survive the round trip.

Separately, the v2 mock test is **flaky**, and not hypothetically: `InfluxDBSinkTest.testOpenWriteCloseJson` failed on unrelated PR #39 today with `Wanted but not invoked: writeApiBlocking.writePoints(<any List>)`.

### Root cause of the flake

`BatchSink.write()` queues the record and, once `batchSize` records are pending, dispatches the flush to a **background** `ScheduledExecutorService`:

```java
if (currentSize >= batchSize) {
    flushExecutor.execute(this::flush);
}
```

The test waited a fixed `Thread.sleep(100)` and then asserted `writePoints` had been called. Under CI load the executor had not yet run the flush, so the verification failed. Nothing was wrong with the sink.

### Modifications

The v1 and v2 sinks are **separate code paths**, so they get separate integration tests, each next to the code it covers.

**`v2/InfluxDBSinkIntegrationTest`** — runs the v2 sink against a real `influxdb:2.7` container. The container is initialized with `DOCKER_INFLUXDB_INIT_MODE=setup`, which provisions the org, bucket, and admin token; the sink then authenticates against that server with the token, so the real `InfluxDBClientBuilderImpl` token-auth path is exercised end to end. Two records are written through the sink's real client and read back with Flux, asserting measurement, tags, field value, and persisted timestamp.

**`v1/InfluxDBGenericRecordSinkIntegrationTest`** — runs the v1 sink against a real `influxdb:1.8` container. v1 uses the `org.influxdb` client, the `BatchPoints` line-protocol API, and a database/retention-policy model instead of v2's org/bucket/token model. HTTP auth is enabled on the container so `InfluxDBBuilderImpl`'s authenticated branch is covered too. Records are read back with `SELECT * FROM cpu`.

In both, `batchTimeMs` is set high so the assertion exercises the batch-size flush path rather than the timer, and both are bounded with a `timeOut`.

**Deflake `v2/InfluxDBSinkTest`** — replace the fixed `Thread.sleep(100)` with an Awaitility poll, so the test waits for the asynchronous flush instead of racing it. The assertion is unchanged.

### Verifying this change

Full module suite passes locally:

```
v1.InfluxDBGenericRecordSinkIntegrationTest > testWritesReachInfluxDb PASSED
v2.InfluxDBSinkIntegrationTest > testWritesReachInfluxDb PASSED
v2.InfluxDBSinkTest > testOpenWriteCloseJson PASSED
BUILD SUCCESSFUL
```

Both integration tests were also checked for vacuous success. Pointing the v2 sink at a nonexistent bucket, and the v1 sink at a nonexistent database, each makes the corresponding test fail with `ConditionTimeoutException ... for input of <[]>` rather than passing silently — confirming they genuinely observe the data reaching InfluxDB.

### Notes

- `GenericContainer` is used rather than Testcontainers' `InfluxDBContainer`: that class targets the 1.x line and does not perform v2's `setup` initialization, so it cannot provision the org/bucket/token the v2 sink needs.