### PR TITLE
[improve][ci] Run the integrationTest source set in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         include:
           - name: Connectors
-            tasks: test
+            tasks: test integrationTest
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
### Motivation

The `mqtt` module ships a real Testcontainers integration test — `MqttSinkIntegrationTest`, added alongside the connector in #22 — in a separate `integrationTest` source set, with its own `integrationTest` Gradle task.

The CI workflow's tests matrix only runs `test`:

```yaml
matrix:
  include:
    - name: Connectors
      tasks: test
```

So that integration test **has never run on a pull request**. The coverage exists but is not enforced: a change that broke MQTT delivery would go green.

This was found while auditing connectors for missing integration tests (#55). Every other module keeps its container tests in `src/test`, where CI picks them up; `mqtt` is the sole module with a separate source set.

### Modifications

Add `integrationTest` to the matrix tasks. Verified that the task resolves repo-wide — `./gradlew integrationTest --dry-run` succeeds, currently selecting only `:mqtt:integrationTest`.

Keeping the source set (rather than moving the test into `src/test`) preserves whatever intent led to the split, and leaves room for other modules to separate slow container tests from fast unit tests later.

### Verifying this change

```
./gradlew :mqtt:integrationTest
org.apache.pulsar.io.mqtt.MqttSinkIntegrationTest > testWriteE2EWithMosquitto PASSED
BUILD SUCCESSFUL in 18s
```

The test was also mutation-checked: publishing to a different topic than the subscriber listens on makes it fail, so it genuinely guards delivery rather than passing against a broken target.

### Note

This adds container-based work to the per-PR job. `:mqtt:integrationTest` takes ~18s locally, so the impact is small, but it is worth being explicit that the `Tests - Connectors` job now starts a Mosquitto container.