### PR TITLE
[fix][io] Do not drop files when the work queue rejects an offer

### DIFF
--- a/file/src/main/java/org/apache/pulsar/io/file/FileListingTask.java
+++ b/file/src/main/java/org/apache/pulsar/io/file/FileListingTask.java
@@ -109,9 +109,12 @@ public class FileListingTask implements Runnable {
                             // The file stays tracked until the cleanup thread renames or
                             // deletes it, which closes the windows where a file is on disk
                             // but in none of the downstream queues.
+                            // Track the file only once the queue has accepted it: a bounded
+                            // workQueue rejects offers when full, and a file recorded as
+                            // offered but never enqueued would never be retried.
                             for (File f: listing) {
-                                if (alreadyOffered.add(f)) {
-                                    workQueue.offer(f);
+                                if (!alreadyOffered.contains(f) && workQueue.offer(f)) {
+                                    alreadyOffered.add(f);
                                 }
                             }
                         }

--- a/file/src/test/java/org/apache/pulsar/io/file/FileListingTaskBoundedQueueTest.java
+++ b/file/src/test/java/org/apache/pulsar/io/file/FileListingTaskBoundedQueueTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.file;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.testng.annotations.Test;
+
+/**
+ * The listing task must never lose a file when the work queue is bounded.
+ *
+ * <p>{@code workQueue} is unbounded today, so {@code offer()} always succeeds. If it is ever
+ * bounded — as proposed in #28 to cap memory under a backlog — {@code offer()} starts returning
+ * {@code false} when the queue is full. Recording a file as offered before the queue accepts it
+ * would drop that file permanently: the tracking set only forgets files that leave the disk, so a
+ * rejected file is never retried.
+ *
+ * <p>These tests bound the queue themselves, so they hold regardless of what {@code FileSource}
+ * does, and they fail against the unfixed listing task.
+ */
+public class FileListingTaskBoundedQueueTest extends AbstractFileTest {
+
+    private static final int POLLING_INTERVAL_MS = 100;
+
+    private void startListing(BlockingQueue<File> queue, BlockingQueue<File> inProcess,
+            BlockingQueue<File> recentlyProcessed) throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("inputDirectory", directory.toString());
+        map.put("keepFile", Boolean.FALSE);
+        map.put("pollingInterval", POLLING_INTERVAL_MS);
+
+        executor.execute(new FileListingTask(FileSourceConfig.load(map), queue, inProcess, recentlyProcessed));
+    }
+
+    /**
+     * A file rejected by a full queue must be offered again once space frees up, rather than
+     * being silently forgotten.
+     */
+    @Test
+    public final void rejectedFilesAreRetriedOnceTheQueueDrains() throws IOException {
+        BlockingQueue<File> boundedQueue = new LinkedBlockingQueue<>(1);
+        BlockingQueue<File> inProcess = new LinkedBlockingQueue<>();
+        BlockingQueue<File> recentlyProcessed = new LinkedBlockingQueue<>();
+
+        try {
+            generateFiles(3);
+            startListing(boundedQueue, inProcess, recentlyProcessed);
+
+            // The queue holds one file; the other two were rejected.
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .until(() -> boundedQueue.size() == 1);
+
+            // Drain the queue one file at a time, as a consumer would. Every file must eventually
+            // be handed over: nothing may be dropped because an earlier offer was rejected.
+            Set<File> drained = new HashSet<>();
+            Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                    .pollInterval(100, TimeUnit.MILLISECONDS)
+                    .until(() -> {
+                        File taken = boundedQueue.poll();
+                        if (taken != null) {
+                            drained.add(taken);
+                        }
+                        return drained.size() == 3;
+                    });
+
+            assertEquals(drained.size(), 3, "every file on disk must reach the work queue");
+        } catch (InterruptedException | ExecutionException e) {
+            fail("Unable to generate files" + e.getLocalizedMessage());
+        } finally {
+            cleanUp();
+        }
+    }
+
+    /**
+     * Draining must not cause a file still on disk to be offered twice — the exactly-once
+     * property has to survive the retry path added for bounded queues.
+     */
+    @Test
+    public final void filesAreNotOfferedTwiceWhileTheyRemainOnDisk() throws IOException {
+        BlockingQueue<File> boundedQueue = new LinkedBlockingQueue<>(10);
+        BlockingQueue<File> inProcess = new LinkedBlockingQueue<>();
+        BlockingQueue<File> recentlyProcessed = new LinkedBlockingQueue<>();
+
+        try {
+            generateFiles(3);
+            startListing(boundedQueue, inProcess, recentlyProcessed);
+
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .until(() -> boundedQueue.size() == 3);
+
+            // Several more listing passes run while the files remain on disk and queued.
+            Thread.sleep(POLLING_INTERVAL_MS * 5L);
+
+            assertEquals(boundedQueue.size(), 3, "files already queued must not be offered again");
+        } catch (InterruptedException | ExecutionException e) {
+            fail("Unable to generate files" + e.getLocalizedMessage());
+        } finally {
+            cleanUp();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #80

### Motivation

`FileListingTask` records a file as offered **before** checking that the work queue accepted it:

```java
for (File f : listing) {
    if (alreadyOffered.add(f)) {
        workQueue.offer(f);      // return value ignored
    }
}
```

Ignoring `offer()`'s result is safe only while `workQueue` is unbounded, which it is today. The moment it is bounded, `offer()` returns `false` when the queue is full — the file is already in `alreadyOffered`, and the prune step only forgets files that have **left the disk**. The file is never enqueued, never retried, never processed.

This is not theoretical: #28 ("Prevent OOM in FileSource by bounding internal queues") does exactly that. It is green and conflicts with nothing, because it touches different files — so the loss would have merged silently. Worse, the failure triggers precisely under the backlog #28 exists to survive.

Reproduced with a bounded `workQueue` of capacity 1 and 3 files on disk:

```
WORKQUEUE_SIZE=1
FILES_ON_DISK=3
AFTER_DRAIN_REOFFERED=0     <-- the other 2 files are never re-offered
```

The assumption is mine, introduced in #41. This PR removes it so #28 can land safely.

### Modifications

Track a file only once the queue has accepted it:

```java
for (File f : listing) {
    if (!alreadyOffered.contains(f) && workQueue.offer(f)) {
        alreadyOffered.add(f);
    }
}
```

A rejected file is simply retried on the next listing pass — the lister slows to the consumer's rate rather than discarding work, which is the back-pressure a bounded queue is meant to produce. The `keepFile=true` branch re-checks `workQueue.contains(f)` each pass and is unaffected.

### Tests

`FileListingTaskBoundedQueueTest` bounds the queue itself, so it holds regardless of what `FileSource` constructs today and guards the invariant ahead of #28:

- `rejectedFilesAreRetriedOnceTheQueueDrains` — 3 files, queue capacity 1; every file must reach the queue as it drains.
- `filesAreNotOfferedTwiceWhileTheyRemainOnDisk` — the exactly-once property from #41 must survive the new retry path.

### Verifying this change

The regression test genuinely catches the bug. Reverting `FileListingTask` to master's version:

```
rejectedFilesAreRetriedOnceTheQueueDrains FAILED
    org.awaitility.core.ConditionTimeoutException: Condition ... was not fulfilled within 30 seconds.
filesAreNotOfferedTwiceWhileTheyRemainOnDisk PASSED
```

The second test passes either way, as it should — it pins the property the bug never broke.

With the fix applied, the full `:file:test` suite is green (`BUILD SUCCESSFUL in 1m 58s`).

### Note on the earlier revision

An earlier push of this branch accidentally carried the Kafka integration test from #76, as Copilot correctly flagged. The branch has been rebuilt on current master — which now contains #14 (renaming `FileListingThread` → `FileListingTask`) and #76 — and the diff is now exactly two files, both in `file/`.

### Suggested merge order

1. this PR
2. #28 — rebase; its bounded queues then cannot drop files