### PR TITLE
[fix][test] Wait for the public tenant before creating the test namespace

### DIFF
--- a/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarSchemaHistoryTest.java
+++ b/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarSchemaHistoryTest.java
@@ -32,11 +32,13 @@ import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
+import org.awaitility.Awaitility;
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testng.annotations.AfterMethod;
@@ -71,6 +73,16 @@ public class PulsarSchemaHistoryTest {
         admin = PulsarAdmin.builder()
                 .serviceHttpUrl(pulsarContainer.getHttpServiceUrl())
                 .build();
+
+        // The broker creates the "public" tenant asynchronously during bootstrap, and the
+        // container's wait strategy can return before that finishes. Creating the namespace
+        // immediately then fails with "Tenant does not exist" (HTTP 404). Seen in CI:
+        // https://github.com/apache/pulsar-connectors/actions/runs/29055562433
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(250, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .until(() -> admin.tenants().getTenants().contains("public"));
 
         // Create namespace used by tests
         admin.namespaces().createNamespace("public/my-ns");


### PR DESCRIPTION
Fixes #83

### Motivation

`PulsarSchemaHistoryTest` intermittently fails in `setup()`:

```
PulsarSchemaHistoryTest > setup FAILED
    org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: Tenant does not exist
        javax.ws.rs.NotFoundException: HTTP 404 {"reason":"Tenant does not exist"}
```

It struck an unrelated PR today — #79, a DynamoDB client-construction fix, whose own tests all passed: [run 29055562433](https://github.com/apache/pulsar-connectors/actions/runs/29055562433). Because `setup()` is a `@BeforeMethod`, one lost race takes down every test in the class and fails a PR that never touched this code.

### Root cause

`setup()` creates the namespace as soon as the container reports ready:

```java
pulsarContainer.start();
...
admin.namespaces().createNamespace("public/my-ns");   // may race
```

The broker creates the `public` tenant **asynchronously** during bootstrap. `PulsarContainer`'s wait strategy returns once the port and startup log are up, which can precede tenant creation.

### Modifications

Poll for the `public` tenant before creating the namespace, with `ignoreExceptions()` so admin calls made while the broker is still warming do not fail the wait.

### Verifying this change

`./gradlew :debezium:pulsar-io-debezium-core:test` — `BUILD SUCCESSFUL in 1m 12s`, all 6 tests pass.

**An honest caveat on that evidence:** this flake does not reproduce locally, so a green local run is weak proof. I probed it directly — calling `admin.tenants().getTenants()` immediately after `start()` returns `[public, pulsar]` every time on a warm machine, meaning the wait is a no-op locally and the race window only opens on CI's slower, contended runners. What the change does guarantee is that the 404 window is closed wherever it exists: the wait returns as soon as the tenant is visible, and adds nothing when it already is.

### Note

This is the third timing-flake of the same shape found in this repo today, after the file connector's queue hand-off races (#12 / #41) and the InfluxDB sink's fixed-`Thread.sleep` assertion (#53 / #73). Each assumed an asynchronous step had completed because a synchronous one had.