### PR TITLE
[fix][test] Replace fixed sleeps with Awaitility polls in sink tests

### DIFF
--- a/hbase/src/test/java/org/apache/pulsar/io/hbase/sink/HbaseGenericRecordSinkTest.java
+++ b/hbase/src/test/java/org/apache/pulsar/io/hbase/sink/HbaseGenericRecordSinkTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.hbase.client.Get;
@@ -46,6 +47,7 @@ import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.functions.source.PulsarSourceConfig;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.hbase.TableUtils;
+import org.awaitility.Awaitility;
 import org.mockito.Mock;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -155,12 +157,13 @@ public class HbaseGenericRecordSinkTest {
         // write should success.
         sink.write(record);
         log.info("executed write");
-        // sleep to wait backend flush complete
-        Thread.sleep(500);
-
-        // value has been written to hbase table, read it out and verify.
+        // The sink flushes on a background executor; poll for the row rather than racing it.
         Table table = TableUtils.getTable(map);
         Get scan = new Get(Bytes.toBytes(obj.getRowKey()));
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(() -> !table.get(scan).isEmpty());
+
         Result result = table.get(scan);
         byte[] byteName = result.getValue(Bytes.toBytes(familyName), Bytes.toBytes(name));
         byte[] byteAddress = result.getValue(Bytes.toBytes(familyName), Bytes.toBytes(address));

--- a/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsSequentialSinkTest.java
+++ b/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsSequentialSinkTest.java
@@ -19,9 +19,11 @@
 package org.apache.pulsar.io.hdfs3.sink.seq;
 
 import static org.mockito.Mockito.times;
+import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 import org.apache.pulsar.io.hdfs3.sink.AbstractHdfsSinkTest;
+import org.awaitility.Awaitility;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -42,8 +44,9 @@ public class HdfsSequentialSinkTest extends AbstractHdfsSinkTest<Long, String> {
         assertNotNull(sink);
         send(100);
 
-        Thread.sleep(2000);
-        verify(mockRecord, times(100)).ack();
+        // The sink syncs on a background interval; poll rather than racing it.
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(100)).ack());
         sink.close();
     }
 
@@ -57,8 +60,9 @@ public class HdfsSequentialSinkTest extends AbstractHdfsSinkTest<Long, String> {
         assertNotNull(sink);
         send(5000);
 
-        Thread.sleep(2000);
-        verify(mockRecord, times(5000)).ack();
+        // The sink syncs on a background interval; poll rather than racing it.
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(5000)).ack());
         sink.close();
     }
 

--- a/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsTextSinkTest.java
+++ b/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsTextSinkTest.java
@@ -19,9 +19,9 @@
 package org.apache.pulsar.io.hdfs3.sink.seq;
 
 import static org.mockito.Mockito.times;
-import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.io.hdfs3.sink.AbstractHdfsSinkTest;
 import org.awaitility.Awaitility;
 import org.testng.SkipException;

--- a/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsTextSinkTest.java
+++ b/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsTextSinkTest.java
@@ -19,9 +19,11 @@
 package org.apache.pulsar.io.hdfs3.sink.seq;
 
 import static org.mockito.Mockito.times;
+import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 import org.apache.pulsar.io.hdfs3.sink.AbstractHdfsSinkTest;
+import org.awaitility.Awaitility;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -43,8 +45,9 @@ public class HdfsTextSinkTest extends AbstractHdfsSinkTest<String, String> {
         assertNotNull(mockRecord);
         send(100);
 
-        Thread.sleep(2000);
-        verify(mockRecord, times(100)).ack();
+        // The sink syncs on a background interval; poll rather than racing it.
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(100)).ack());
         sink.close();
     }
 
@@ -59,8 +62,9 @@ public class HdfsTextSinkTest extends AbstractHdfsSinkTest<String, String> {
         assertNotNull(mockRecord);
         send(5000);
 
-        Thread.sleep(2000);
-        verify(mockRecord, times(5000)).ack();
+        // The sink syncs on a background interval; poll rather than racing it.
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(5000)).ack());
         sink.close();
     }
 

--- a/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkTest.java
+++ b/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import com.google.common.collect.Maps;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Message;
@@ -39,6 +40,7 @@ import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.core.SinkContext;
+import org.awaitility.Awaitility;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
 import org.mockito.Mock;
@@ -150,8 +152,8 @@ public class InfluxDBGenericRecordSinkTest {
 
         influxSink.write(record);
 
-        Thread.sleep(1000);
-
-        verify(influxDB, times(1)).write(any(BatchPoints.class));
+        // BatchSink flushes on a background executor; poll rather than racing it.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(influxDB, times(1)).write(any(BatchPoints.class)));
     }
 }

--- a/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkTest.java
+++ b/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkTest.java
@@ -42,8 +42,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
+import org.awaitility.Awaitility;
 import org.bson.BsonDocument;
 import org.mockito.Mock;
 import org.reactivestreams.Publisher;
@@ -149,9 +151,9 @@ public class MongoSinkTest {
         sink.open(map, mockSinkContext);
         sink.write(mockRecord);
 
-        Thread.sleep(1000);
-
-        verify(mockRecord, times(1)).fail();
+        // The sink flushes on a background executor; poll rather than racing it.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(1)).fail());
     }
 
     @Test
@@ -161,9 +163,9 @@ public class MongoSinkTest {
         sink.open(map, mockSinkContext);
         sink.write(mockRecord);
 
-        Thread.sleep(1000);
-
-        verify(mockRecord, times(1)).ack();
+        // The sink flushes on a background executor; poll rather than racing it.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(1)).ack());
     }
 
     @Test
@@ -175,10 +177,12 @@ public class MongoSinkTest {
         sink.write(mockRecord);
         sink.write(mockRecord);
 
-        Thread.sleep(1000);
-
-        verify(mockRecord, times(2)).ack();
-        verify(mockRecord, times(1)).fail();
+        // The sink flushes on a background executor; poll rather than racing it.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    verify(mockRecord, times(2)).ack();
+                    verify(mockRecord, times(1)).fail();
+                });
     }
 
     @Test
@@ -188,9 +192,9 @@ public class MongoSinkTest {
         sink.open(map, mockSinkContext);
         sink.write(mockRecord);
 
-        Thread.sleep(1000);
-
-        verify(mockRecord, times(1)).fail();
+        // The sink flushes on a background executor; poll rather than racing it.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(1)).fail());
     }
 
     @Test
@@ -200,8 +204,8 @@ public class MongoSinkTest {
         sink.open(map, mockSinkContext);
         sink.write(mockRecord);
 
-        Thread.sleep(1000);
-
-        verify(mockRecord, times(1)).fail();
+        // The sink flushes on a background executor; poll rather than racing it.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(mockRecord, times(1)).fail());
     }
 }


### PR DESCRIPTION
Fixes #85

### Motivation

An audit for timing flakes found the same defect in four more modules. Each writes to a sink that flushes **asynchronously**, waits a **fixed** `Thread.sleep`, then asserts the flush happened. On a slow runner the flush has not run and the assertion fails — the sink is fine, the test raced it.

This shape has already failed two unrelated PRs today:

- `InfluxDBSinkTest.testOpenWriteCloseJson` (v2) broke #39 → fixed in #73
- `PulsarSchemaHistoryTest.setup` broke #79 → fixed in #84

### Findings

| Module | Test | Sleep | Then asserts | Async mechanism |
|---|---|---|---|---|
| `hdfs3` | `HdfsSequentialSinkTest.write5000Test` | 2000 ms | `verify(..., times(5000)).ack()` | `syncInterval` background sync |
| `hdfs3` | `HdfsSequentialSinkTest`, `HdfsTextSinkTest` | 2000 ms | `verify(..., times(100)).ack()` | same |
| `mongo` | `MongoSinkTest` × 5 sites | 1000 ms | `verify(..., times(n)).ack()/.fail()` | `flushExecutor.scheduleAtFixedRate` |
| `influxdb` v1 | `InfluxDBGenericRecordSinkTest` | 1000 ms | `verify(influxDB, times(1)).write(...)` | `BatchSink` flush executor — the very class whose v2 sibling flaked |
| `hbase` | `HbaseGenericRecordSinkTest` | 500 ms | reads the row back | `HbaseAbstractSink` batch flush |

`write5000Test` is the sharpest: 5000 acks asserted within a hard-coded 2 seconds.

### Modifications

Replace each fixed sleep with an Awaitility poll on the same condition. **The assertions are unchanged** — only the waiting is. `awaitility` is already on every module's test classpath via the shared java-conventions plugin. The tests also get faster, since a poll returns as soon as the condition holds rather than always sleeping the full duration.

### Verifying this change

All four suites pass: `./gradlew :mongo:test :influxdb:test :hdfs3:test :hbase:test` → `BUILD SUCCESSFUL`.

More importantly, the race is **demonstrated**, not asserted. Taking master's `MongoSinkTest` and shortening its sleep from 1000 ms to 1 ms — simulating a runner slow enough that the flush has not fired — reproduces the CI signature exactly:

```
MongoSinkTest > testWriteBadMessage FAILED
    Wanted but not invoked: ...
MongoSinkTest > testWriteGoodMessage FAILED
    Wanted but not invoked: ...
```

The Awaitility version passes with **no sleep at all**, because it waits on the condition rather than on a guessed duration.

### Notes

- `HbaseGenericRecordSinkTest` is `@Test(enabled = false)` and does not run today, so its change is compile-only. Included so the pattern is not reintroduced when it is re-enabled.
- Deliberately **not** changed, with reasons, in #85: `redis` (sleeps but asserts nothing afterwards), `jdbc/sqlite` (sleep inside a retry loop), `azure-data-explorer` (credential-gated, never runs in CI — see #49), and `file` (its sleeps are deliberate soak windows; its races were fixed in #41 and #71).