### PR TITLE
[improve][io] Extend RMQ source with connection, queue and exchange options

### DIFF
--- a/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
+++ b/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
@@ -21,6 +21,9 @@ package org.apache.pulsar.io.rabbitmq;
 import com.google.common.base.Preconditions;
 import com.rabbitmq.client.ConnectionFactory;
 import java.io.Serializable;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLContext;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
@@ -51,6 +54,15 @@ public class RabbitMQAbstractConfig implements Serializable {
         defaultValue = "5672",
         help = "The RabbitMQ port to connect to")
     private int port = 5672;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "false",
+        help = "Set to true to establish a TLS/SSL connection to RabbitMQ. The server certificate is "
+                + "validated against the JVM trust store and the server hostname is verified. To trust a "
+                + "private CA or self-signed certificate, add it to the JVM trust store "
+                + "(e.g. via -Djavax.net.ssl.trustStore).")
+    private boolean ssl = false;
 
     @FieldDoc(
         required = true,
@@ -115,7 +127,7 @@ public class RabbitMQAbstractConfig implements Serializable {
         Preconditions.checkNotNull(connectionName, "connectionName property not set.");
     }
 
-    public ConnectionFactory createConnectionFactory() {
+    public ConnectionFactory createConnectionFactory() throws NoSuchAlgorithmException, KeyManagementException {
         ConnectionFactory connectionFactory = new ConnectionFactory();
         connectionFactory.setHost(this.host);
         connectionFactory.setUsername(this.username);
@@ -127,6 +139,13 @@ public class RabbitMQAbstractConfig implements Serializable {
         connectionFactory.setHandshakeTimeout(this.handshakeTimeout);
         connectionFactory.setRequestedHeartbeat(this.requestedHeartbeat);
         connectionFactory.setPort(this.port);
+        if (this.ssl) {
+            // Use the JVM's default SSL context: it trusts the default trust store and negotiates the
+            // highest mutually supported TLS version. Together with hostname verification this avoids the
+            // insecure trust-all behaviour of the no-arg ConnectionFactory.useSslProtocol().
+            connectionFactory.useSslProtocol(SSLContext.getDefault());
+            connectionFactory.enableHostnameVerification();
+        }
         return connectionFactory;
     }
 }

--- a/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -114,8 +114,8 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 throws IOException {
             long deliveryTag = envelope.getDeliveryTag();
             Map<String, String> pulsarProperties = new HashMap<>();
-            pulsarProperties.put("consumerTag", consumerTag);
-            pulsarProperties.put("queueName", queueName);
+            pulsarProperties.put("__rabbitmq_consumer_tag", consumerTag);
+            pulsarProperties.put("__rabbitmq_queue_name", queueName);
             source.consume(new RabbitMQRecord(Optional.ofNullable(envelope.getRoutingKey()), body, () -> {
                 // acknowledge this delivery tag to RabbitMQ
                 try {

--- a/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -25,6 +25,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
@@ -51,6 +52,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
     private Connection rabbitMQConnection;
     private Channel rabbitMQChannel;
     private RabbitMQSourceConfig rabbitMQSourceConfig;
+    private String queueName;
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
@@ -64,19 +66,33 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 rabbitMQConnection.getPort()
         );
         rabbitMQChannel = rabbitMQConnection.createChannel();
+        AMQP.Queue.DeclareOk queueDeclaration;
         if (rabbitMQSourceConfig.isPassive()) {
-            rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
+            queueDeclaration = rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
         } else {
-            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(), false, false, false, null);
+            queueDeclaration = rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
+                                                        rabbitMQSourceConfig.isDurable(),
+                                                        rabbitMQSourceConfig.isExclusive(),
+                                                        rabbitMQSourceConfig.isAutoDelete(),
+                                                        null
+            );
         }
+        queueName = queueDeclaration.getQueue();
         logger.info("Setting channel.basicQos({}, {}).",
                 rabbitMQSourceConfig.getPrefetchCount(),
                 rabbitMQSourceConfig.isPrefetchGlobal()
         );
         rabbitMQChannel.basicQos(rabbitMQSourceConfig.getPrefetchCount(), rabbitMQSourceConfig.isPrefetchGlobal());
+        String exchange = rabbitMQSourceConfig.getExchangeName();
+        String routingKey = rabbitMQSourceConfig.getRoutingKey();
+        if (exchange != null && !exchange.isEmpty()) {
+            // note: the exchange is expected to already exist; it is not declared here
+            rabbitMQChannel.queueBind(queueName, exchange, routingKey);
+            logger.info("Bound queue {} to exchange {} with routing key {}.", queueName, exchange, routingKey);
+        }
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
-        rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
-        logger.info("A consumer for queue {} has been successfully started.", rabbitMQSourceConfig.getQueueName());
+        rabbitMQChannel.basicConsume(queueName, consumer);
+        logger.info("A consumer for queue {} has been successfully started.", queueName);
     }
 
     @Override
@@ -97,6 +113,9 @@ public class RabbitMQSource extends PushSource<byte[]> {
         public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
                 throws IOException {
             long deliveryTag = envelope.getDeliveryTag();
+            Map<String, String> pulsarProperties = new HashMap<>();
+            pulsarProperties.put("consumerTag", consumerTag);
+            pulsarProperties.put("queueName", queueName);
             source.consume(new RabbitMQRecord(Optional.ofNullable(envelope.getRoutingKey()), body, () -> {
                 // acknowledge this delivery tag to RabbitMQ
                 try {
@@ -111,7 +130,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 } catch (IOException e) {
                     logger.error("Error while negatively acknowledging envelope {}.", envelope, e);
                 }
-            }));
+            }, pulsarProperties));
         }
     }
 
@@ -121,6 +140,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
         private final byte[] value;
         private final Runnable ackFunction;
         private final Runnable nackFunction;
+        private final Map<String, String> properties;
 
         @Override
         public void ack() {

--- a/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -97,8 +97,12 @@ public class RabbitMQSource extends PushSource<byte[]> {
 
     @Override
     public void close() throws Exception {
-        rabbitMQChannel.close();
-        rabbitMQConnection.close();
+        if (rabbitMQChannel != null) {
+            rabbitMQChannel.close();
+        }
+        if (rabbitMQConnection != null) {
+            rabbitMQConnection.close();
+        }
     }
 
     private class RabbitMQConsumer extends DefaultConsumer {

--- a/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -63,6 +63,39 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
             help = "Set true if the queue should be declared passively - ie to preserve durability/timeout settings")
     private boolean passive = false;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue should survive a broker restart")
+    private boolean durable = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue can be used by only one connection and get deleted when it closes")
+    private boolean exclusive = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue should get deleted when the last consumer unsubscribes")
+    private boolean autoDelete = false;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "The name of an existing exchange to bind the queue to. The exchange must already exist; "
+                + "it is not declared by the connector. Leave empty to consume directly from the queue "
+                + "without binding to an exchange.")
+    private String exchangeName;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "#",
+            help = "The routing key used when binding the queue to the exchange. "
+                    + "Only used when exchangeName is set.")
+    private String routingKey = "#";
+
     public static RabbitMQSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), RabbitMQSourceConfig.class);

--- a/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -109,6 +109,10 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
     public void validate() {
         super.validate();
         Preconditions.checkNotNull(queueName, "queueName property not set.");
+        Preconditions.checkArgument(!passive || !queueName.isEmpty(),
+                "queueName must be non-empty when passive is true.");
+        Preconditions.checkArgument(exchangeName == null || exchangeName.isEmpty() || routingKey != null,
+                "routingKey must not be null when exchangeName is set.");
         Preconditions.checkArgument(prefetchCount >= 0, "prefetchCount must be non-negative.");
     }
 }

--- a/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -161,25 +161,41 @@ public class RabbitMQSourceConfigTest {
 
     @Test
     public final void validValidateTest() throws IOException {
-        Map<String, Object> map = new HashMap<>();
-        map.put("host", "localhost");
-        map.put("port", "5672");
-        map.put("virtualHost", "/");
-        map.put("username", "guest");
-        map.put("password", "guest");
-        map.put("queueName", "test-queue");
-        map.put("connectionName", "test-connection");
-        map.put("requestedChannelMax", "0");
-        map.put("requestedFrameMax", "0");
-        map.put("connectionTimeout", "60000");
-        map.put("handshakeTimeout", "10000");
-        map.put("requestedHeartbeat", "60");
-        map.put("prefetchCount", "0");
-        map.put("prefetchGlobal", "false");
-        map.put("passive", "false");
+        RabbitMQSourceConfig config = validConfig();
+        config.validate();
+    }
 
-        SourceContext sourceContext = Mockito.mock(SourceContext.class);
-        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
+    @Test
+    public final void emptyQueueNameForNonPassiveDeclarationValidateTest() throws IOException {
+        RabbitMQSourceConfig config = validConfig()
+                .setQueueName("")
+                .setPassive(false);
+        config.validate();
+    }
+
+    @Test
+    public final void emptyRoutingKeyWithExchangeValidateTest() throws IOException {
+        RabbitMQSourceConfig config = validConfig()
+                .setExchangeName("test-exchange")
+                .setRoutingKey("");
+        config.validate();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "queueName must be non-empty when passive is true\\.")
+    public final void emptyQueueNameForPassiveDeclarationValidateTest() throws IOException {
+        RabbitMQSourceConfig config = validConfig()
+                .setQueueName("")
+                .setPassive(true);
+        config.validate();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "routingKey must not be null when exchangeName is set\\.")
+    public final void nullRoutingKeyWithExchangeValidateTest() throws IOException {
+        RabbitMQSourceConfig config = validConfig()
+                .setExchangeName("test-exchange")
+                .setRoutingKey(null);
         config.validate();
     }
 
@@ -250,6 +266,26 @@ public class RabbitMQSourceConfigTest {
         SourceContext sourceContext = Mockito.mock(SourceContext.class);
         RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
         config.validate();
+    }
+
+    private RabbitMQSourceConfig validConfig() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("host", "localhost");
+        map.put("port", "5672");
+        map.put("virtualHost", "/");
+        map.put("username", "guest");
+        map.put("password", "guest");
+        map.put("queueName", "test-queue");
+        map.put("connectionName", "test-connection");
+        map.put("requestedChannelMax", "0");
+        map.put("requestedFrameMax", "0");
+        map.put("connectionTimeout", "60000");
+        map.put("handshakeTimeout", "10000");
+        map.put("requestedHeartbeat", "60");
+        map.put("prefetchCount", "0");
+        map.put("prefetchGlobal", "false");
+        map.put("passive", "false");
+        return RabbitMQSourceConfig.load(map, Mockito.mock(SourceContext.class));
     }
 
     private File getFile(String name) {

--- a/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import com.rabbitmq.client.ConnectionFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -61,6 +62,7 @@ public class RabbitMQSourceConfigTest {
         assertFalse(config.isAutoDelete());
         assertNull(config.getExchangeName());
         assertEquals("#", config.getRoutingKey());
+        assertFalse(config.isSsl());
     }
 
     @Test
@@ -86,6 +88,7 @@ public class RabbitMQSourceConfigTest {
         map.put("autoDelete", "true");
         map.put("exchangeName", "test-exchange");
         map.put("routingKey", "test.#");
+        map.put("ssl", "true");
 
         SourceContext sourceContext = Mockito.mock(SourceContext.class);
         RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
@@ -111,6 +114,7 @@ public class RabbitMQSourceConfigTest {
         assertEquals(true, config.isAutoDelete());
         assertEquals("test-exchange", config.getExchangeName());
         assertEquals("test.#", config.getRoutingKey());
+        assertEquals(true, config.isSsl());
     }
 
     @Test
@@ -177,6 +181,26 @@ public class RabbitMQSourceConfigTest {
         SourceContext sourceContext = Mockito.mock(SourceContext.class);
         RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
         config.validate();
+    }
+
+    @Test
+    public final void createConnectionFactoryWithSslTest() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        map.put("host", "localhost");
+        map.put("port", "5671");
+        map.put("virtualHost", "/");
+        map.put("username", "guest");
+        map.put("password", "guest");
+        map.put("queueName", "test-queue");
+        map.put("connectionName", "test-connection");
+        map.put("ssl", "true");
+
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
+
+        // building the factory with ssl enabled must set up the TLS context without throwing
+        ConnectionFactory connectionFactory = config.createConnectionFactory();
+        assertNotNull(connectionFactory);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,

--- a/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.rabbitmq.source;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -55,6 +56,11 @@ public class RabbitMQSourceConfigTest {
         assertEquals(Integer.parseInt("0"), config.getPrefetchCount());
         assertFalse(config.isPrefetchGlobal());
         assertFalse(config.isPassive());
+        assertFalse(config.isDurable());
+        assertFalse(config.isExclusive());
+        assertFalse(config.isAutoDelete());
+        assertNull(config.getExchangeName());
+        assertEquals("#", config.getRoutingKey());
     }
 
     @Test
@@ -75,6 +81,11 @@ public class RabbitMQSourceConfigTest {
         map.put("prefetchCount", "0");
         map.put("prefetchGlobal", "false");
         map.put("passive", "true");
+        map.put("durable", "true");
+        map.put("exclusive", "true");
+        map.put("autoDelete", "true");
+        map.put("exchangeName", "test-exchange");
+        map.put("routingKey", "test.#");
 
         SourceContext sourceContext = Mockito.mock(SourceContext.class);
         RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
@@ -95,6 +106,11 @@ public class RabbitMQSourceConfigTest {
         assertEquals(false, config.isPrefetchGlobal());
         assertEquals(false, config.isPrefetchGlobal());
         assertEquals(true, config.isPassive());
+        assertEquals(true, config.isDurable());
+        assertEquals(true, config.isExclusive());
+        assertEquals(true, config.isAutoDelete());
+        assertEquals("test-exchange", config.getExchangeName());
+        assertEquals("test.#", config.getRoutingKey());
     }
 
     @Test

--- a/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -19,9 +19,15 @@
 package org.apache.pulsar.io.rabbitmq.source;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.rabbitmq.RabbitMQBrokerManager;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSource;
@@ -47,22 +53,7 @@ public class RabbitMQSourceTest {
 
     @Test
     public void testOpenAndWriteSink() throws Exception {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put("host", "localhost");
-        configs.put("port", String.valueOf(rabbitMQBrokerManager.getPort()));
-        configs.put("virtualHost", "default");
-        configs.put("username", rabbitMQBrokerManager.getUser());
-        configs.put("password", rabbitMQBrokerManager.getPassword());
-        configs.put("queueName", "test-queue");
-        configs.put("connectionName", "test-connection");
-        configs.put("requestedChannelMax", "0");
-        configs.put("requestedFrameMax", "0");
-        configs.put("connectionTimeout", "60000");
-        configs.put("handshakeTimeout", "10000");
-        configs.put("requestedHeartbeat", "60");
-        configs.put("prefetchCount", "0");
-        configs.put("prefetchGlobal", "false");
-        configs.put("passive", "false");
+        Map<String, Object> configs = baseConfigs("test-queue");
 
         RabbitMQSource source = new RabbitMQSource();
 
@@ -74,5 +65,64 @@ public class RabbitMQSourceTest {
         source.close();
     }
 
+    @Test(timeOut = 60000)
+    public void testBindToExchangeAndConsumeMessage() throws Exception {
+        String exchange = "test-exchange";
+        String queue = "test-bind-queue";
+        String routingKey = "test.key";
 
+        ConnectionFactory factory = new ConnectionFactory();
+        factory.setHost("localhost");
+        factory.setPort(rabbitMQBrokerManager.getPort());
+        factory.setUsername(rabbitMQBrokerManager.getUser());
+        factory.setPassword(rabbitMQBrokerManager.getPassword());
+        factory.setVirtualHost("default");
+
+        RabbitMQSource source = new RabbitMQSource();
+        SourceContext sourceContext = mock(SourceContext.class);
+
+        try (Connection connection = factory.newConnection();
+             Channel channel = connection.createChannel()) {
+            // the exchange must already exist before the source binds the queue to it
+            channel.exchangeDeclare(exchange, "topic", true);
+
+            Map<String, Object> configs = baseConfigs(queue);
+            configs.put("exchangeName", exchange);
+            configs.put("routingKey", routingKey);
+            configs.put("durable", "true");
+
+            // rabbitmq service may need time to initialize
+            Awaitility.await().ignoreExceptions().pollDelay(Duration.ofSeconds(1))
+                    .untilAsserted(() -> source.open(configs, sourceContext));
+
+            channel.basicPublish(exchange, routingKey, null, "hello".getBytes(StandardCharsets.UTF_8));
+
+            Record<byte[]> record = source.read();
+            assertEquals("hello", new String(record.getValue(), StandardCharsets.UTF_8));
+            assertEquals(queue, record.getProperties().get("queueName"));
+            record.ack();
+        } finally {
+            source.close();
+        }
+    }
+
+    private Map<String, Object> baseConfigs(String queueName) {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("host", "localhost");
+        configs.put("port", String.valueOf(rabbitMQBrokerManager.getPort()));
+        configs.put("virtualHost", "default");
+        configs.put("username", rabbitMQBrokerManager.getUser());
+        configs.put("password", rabbitMQBrokerManager.getPassword());
+        configs.put("queueName", queueName);
+        configs.put("connectionName", "test-connection");
+        configs.put("requestedChannelMax", "0");
+        configs.put("requestedFrameMax", "0");
+        configs.put("connectionTimeout", "60000");
+        configs.put("handshakeTimeout", "10000");
+        configs.put("requestedHeartbeat", "60");
+        configs.put("prefetchCount", "0");
+        configs.put("prefetchGlobal", "false");
+        configs.put("passive", "false");
+        return configs;
+    }
 }

--- a/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -99,7 +99,7 @@ public class RabbitMQSourceTest {
 
             Record<byte[]> record = source.read();
             assertEquals("hello", new String(record.getValue(), StandardCharsets.UTF_8));
-            assertEquals(queue, record.getProperties().get("queueName"));
+            assertEquals(queue, record.getProperties().get("__rabbitmq_queue_name"));
             record.ack();
         } finally {
             source.close();


### PR DESCRIPTION
### Motivation

Years ago, we worked on a project that required us to connect to to an external AMQP source. All our services were already using Pulsar as a source, and we were not particularly happy with the introduction of this asymmetry. We thought we could leverage the official RabbitMQ source connector, but very soon we run into issues that required us to fork it and roll out our own version. This fixes were sitting in our own fork, until today. We believe these small improvements may be of interest to the wider Pulsar community.

In a few words, the requirements we had (and still have) were as follows

> You cannot create your own queues. Instead you have to request a server-named queue (empty queue name in the request). Passive, Exclusive, Non-durable.

The problem is that the current implementation of the RabbitMQ source connector hardcodes some of these values (see [here](https://github.com/apache/pulsar-connectors/blob/518742a3fe7507d0dcde7495063dc603a885c93c/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java#L70)). More concretely, a RabbitMQ queue's [exclusive](https://www.rabbitmq.com/docs/queues#exclusive-queues), [durable](https://www.rabbitmq.com/docs/queues#durability) and `auto-delete` settings were hardcoded to `false`, `false` and `false`, respectively, and couldn't be configured.

Because of the requirements we shared above, we needed to be able to set `exclusive` and `auto-delete` to `true`.

We also needed to be able to bind a queue to a particular [exchange](https://www.rabbitmq.com/docs/exchanges) using a configurable [routing key](https://www.rabbitmq.com/docs/exchanges#topic). None of this was supported by the RabbitMQ source connector.

In our use case, we also needed for the consuming services to be able to access some of the metadata from the AMQP endpoint as if they were connecting directly to the AMQP endpoint, e.g. did the queue name and consumer tag change? that would suggest the source connector restarted and consuming services may need to take an action.

Last but not least, the current implementation of the RabbitMQ source connector does not support connections to secure AMQP endpoints.

Below is an example of how the RabbitMQ source connector could be configured once these changes are merged

```
configs:
    host: "<AMQP-HOST>"
    port: 5671
    ssl: true
    virtualHost: "<AMQP-VIRTUAL-HOST>"
    username: "<AMQP-USERNAME>"
    password: ""
    queueName: ""
    durable: false
    exclusive: true
    autoDelete: true
    exchangeName: "<EXCHANGE-NAME>"
    routingKey: "<ROUTING-KEY>"
    connectionName: "<AMQP-CONNECTION-NAME>"
```

### Modifications

`RabbitMQSource.java` has been extended to allow users to override the previously hardcoded values of important RabbitMQ settings such as `exchange`, `routingKey`, `durable`, `autoDelete` and `exclusive`.  The emitted Pulsar message now includes some AMQP metadata, i.e. [queue name](https://www.rabbitmq.com/docs/queues#names) and [consumer tag](https://www.rabbitmq.com/docs/consumers#consumer-tags), encoded as message properties. The RabbitMQ source connector can now connect to secure AMQP endpoints over TLS.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Extended the existing `RabbitMQSourceConfigTest` and `RabbitMQSourceTest` tests with additional tests to confirm the new configuration parameters are correctly applied and the AMQP fields are correctly propagated to the resulting Pulsar message.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/efcasado/pulsar-connectors/pull/3