### PR TITLE
[fix][test] Bound MqttSinkIntegrationTest container startup so it cannot hang CI

### DIFF
--- a/mqtt/src/integrationTest/java/org/apache/pulsar/io/mqtt/MqttSinkIntegrationTest.java
+++ b/mqtt/src/integrationTest/java/org/apache/pulsar/io/mqtt/MqttSinkIntegrationTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 import com.hivemq.client.mqtt.MqttClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -37,6 +38,7 @@ import org.apache.pulsar.io.core.SinkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -51,7 +53,11 @@ public class MqttSinkIntegrationTest {
     private static final DockerImageName MOSQUITTO_IMAGE = DockerImageName.parse("eclipse-mosquitto:2");
 
     private final GenericContainer<?> mqttContainer = new GenericContainer<>(MOSQUITTO_IMAGE)
-            .withExposedPorts(MQTT_PORT);
+            .withExposedPorts(MQTT_PORT)
+            // Without an explicit wait strategy and startup timeout, a stalled image pull hangs
+            // @BeforeClass with no bound, taking the whole CI job to its 45-minute limit.
+            .waitingFor(Wait.forListeningPort())
+            .withStartupTimeout(Duration.ofMinutes(3));
 
     @BeforeClass(alwaysRun = true)
     public void beforeClass() {
@@ -63,7 +69,7 @@ public class MqttSinkIntegrationTest {
         mqttContainer.stop();
     }
 
-    @Test
+    @Test(timeOut = 120_000)
     public void testWriteE2EWithMosquitto() throws Exception {
         BlockingQueue<String> receivedPayloads = new LinkedBlockingQueue<>();
         CountDownLatch ackLatch = new CountDownLatch(3);


### PR DESCRIPTION
Fixes #89

### Motivation

The `Tests - Connectors` job on #86 ran **45m16s** and was **cancelled** by the runner's `timeout-minutes: 45` — not failed. No diagnostics, 45 minutes of runner time gone, and a red PR with nothing actually wrong with it. [Run 29100595779](https://github.com/apache/pulsar-connectors/actions/runs/29100595779).

`:mqtt:integrationTest` started and never emitted another line; everything else in the job had already passed. The test is careful *inside* the method — every wait is bounded — but container startup in `@BeforeClass` was not:

```java
private final GenericContainer<?> mqttContainer = new GenericContainer<>(MOSQUITTO_IMAGE)
        .withExposedPorts(MQTT_PORT);          // no waitingFor(), no withStartupTimeout()
```

A stalled image pull there hangs with no bound, and neither TestNG (no `@Test(timeOut)`) nor Gradle can interrupt it, so the 45-minute job limit is the only backstop. This test only started running in CI when #74 added `integrationTest` to the matrix, so the hazard was newly live.

### Modifications

- `.waitingFor(Wait.forListeningPort())` with `.withStartupTimeout(Duration.ofMinutes(3))` — bounds the pull/start.
- `@Test(timeOut = 120_000)` as a backstop, consistent with the Debezium tests hardened in #71.

### Verifying this change

Passes normally: `MqttSinkIntegrationTest > testWriteE2EWithMosquitto PASSED`, `BUILD SUCCESSFUL in 8s`.

The guard is demonstrated, not assumed. Forcing an unsatisfiable wait strategy with a short startup timeout makes it **fail in ~28s** instead of hanging:

```
beforeClass FAILED
    org.testcontainers.containers.ContainerLaunchException: Container startup failed for image eclipse-mosquitto:2
        ... Timed out waiting for log output ...
```

### Note

#89 also suggests surfacing Testcontainers logs in CI (none appear in the job output, which is why the cause had to be inferred from timestamps) and, separately, splitting `integrationTest` into its own parallel job — the test suite has roughly doubled in wall-clock time as container tests landed today. Both are follow-ups, not part of this fix.