### PR TITLE
[improve][ci] Shard the test job across three parallel runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,9 +69,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The test job is sharded across module groups so container-backed suites run on
+        # separate runners in parallel. "Other" is a catch-all: it runs `test integrationTest`
+        # for every module EXCEPT those claimed by the explicit groups, so a newly added module
+        # is always covered by exactly one shard and can never be silently skipped.
+        #
+        # INVARIANT: the `-x` exclusions in "Other" must list exactly the modules named in the
+        # "Debezium" and "Streaming & Search" groups — no more, no fewer.
         include:
-          - name: Connectors
-            tasks: test integrationTest
+          - name: Debezium
+            tasks: >-
+              :debezium:pulsar-io-debezium-core:test
+              :debezium:pulsar-io-debezium-mariadb:test
+              :debezium:pulsar-io-debezium-mongodb:test
+              :debezium:pulsar-io-debezium-mssql:test
+              :debezium:pulsar-io-debezium-mysql:test
+              :debezium:pulsar-io-debezium-oracle:test
+              :debezium:pulsar-io-debezium-postgres:test
+          - name: Streaming & Search
+            tasks: >-
+              :elastic-search:test
+              :kafka:test
+              :kafka-connect-adaptor:test
+              :kinesis:test
+              :dynamodb:test
+          - name: Other
+            tasks: >-
+              test integrationTest
+              -x :debezium:pulsar-io-debezium-core:test
+              -x :debezium:pulsar-io-debezium-mariadb:test
+              -x :debezium:pulsar-io-debezium-mongodb:test
+              -x :debezium:pulsar-io-debezium-mssql:test
+              -x :debezium:pulsar-io-debezium-mysql:test
+              -x :debezium:pulsar-io-debezium-oracle:test
+              -x :debezium:pulsar-io-debezium-postgres:test
+              -x :elastic-search:test
+              -x :kafka:test
+              -x :kafka-connect-adaptor:test
+              -x :kinesis:test
+              -x :dynamodb:test
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
### Motivation

The `Tests - Connectors` job runs every module's tests on a single runner. As container-backed suites landed today (Debezium ×7, Kafka, Solr, DynamoDB/LocalStack, InfluxDB v1+v2, MariaDB, ClickHouse, elastic-search, ...), its wall-clock roughly **doubled — from ≈8–10 min to ≈20 min**. Gradle parallelizes within the job, but `ubuntu-latest` gives only 2 cores, so there is little headroom left to exploit in-process.

### Modifications

Split the single test job into **three matrix shards** that run on separate runners in parallel:

| Shard | Modules |
|---|---|
| **Debezium** | the 7 `debezium` modules — Oracle's ~1.6 GB image and LogMiner startup dominate |
| **Streaming & Search** | `elastic-search` (8 Testcontainers classes), `kafka`, `kafka-connect-adaptor`, `kinesis`, `dynamodb` |
| **Other** | catch-all: `test integrationTest` for **every remaining module**, via `-x` exclusions of the two explicit groups |

The **Other** shard is a catch-all by design: a newly added module is picked up by it automatically and can never be silently dropped. The only maintenance rule — stated as an `INVARIANT` comment in the file — is that Other's `-x` list must mirror the two explicit groups exactly.

### Verifying this change

The shards are a **disjoint cover** of the full test set — verified with `--dry-run`, which is authoritative for what each command resolves to:

```
ALL = 40 test/integrationTest tasks
Debezium = 7,  Streaming & Search = 5,  Other = 28   → 7 + 5 + 28 = 40

in ALL but no shard (would be SKIPPED):  (empty)
pairwise overlaps G1∩G2, G1∩G3, G2∩G3:  (all empty)
```

So every task runs in exactly one shard; nothing is skipped or double-run. YAML validated (`YAML.load_file`); the `>-` folded scalars collapse to the single-line command `./gradlew ${{ matrix.tasks }}` expects.

### Expected effect

Wall-clock for the test stage drops from one ~20-min job to roughly `max(shard)` + the fixed ~1–2 min setup, since the shards run concurrently. Each shard also gets its own 2 cores, so Gradle parallelism improves within a shard too.

### Notes

- Balance is approximate — Debezium (Oracle) and Streaming & Search (elastic-search) are the two heaviest clusters, deliberately separated. If one shard dominates in practice, modules can be moved between groups with no structural change.
- Complementary to #91, which bounds the MQTT container startup so a stalled pull fails fast instead of consuming a shard's 45-minute budget.
- Retains `fail-fast: false`, so one shard failing still lets the others report.