### PR TITLE
[fix][io] Flush and sync before closing the HDFS text sink stream

### DIFF
--- a/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/text/HdfsAbstractTextFileSink.java
+++ b/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/text/HdfsAbstractTextFileSink.java
@@ -49,15 +49,19 @@ public abstract class HdfsAbstractTextFileSink<K, V> extends HdfsAbstractSink<K,
     @Override
     public void close() throws Exception {
         // Flush buffered bytes to the HDFS stream, then let the superclass halt the sync thread and
-        // run its final hsync()/ack while the stream is still open, and only then close the writer.
-        // Closing the writer first (the previous order) closed the stream before that final
-        // hsync(), throwing ClosedChannelException whenever unacked records remained at close time.
-        if (writer != null) {
-            writer.flush();
-        }
-        super.close();
-        if (writer != null) {
-            writer.close();
+        // run its final hsync()/ack while the stream is still open. Closing the writer first (the
+        // previous order) closed the stream before that final hsync(), throwing
+        // ClosedChannelException whenever unacked records remained at close time. The writer is
+        // closed in finally so the underlying stream is released even if super.close() throws.
+        try {
+            if (writer != null) {
+                writer.flush();
+            }
+            super.close();
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
         }
     }
 

--- a/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/text/HdfsAbstractTextFileSink.java
+++ b/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/text/HdfsAbstractTextFileSink.java
@@ -48,8 +48,17 @@ public abstract class HdfsAbstractTextFileSink<K, V> extends HdfsAbstractSink<K,
 
     @Override
     public void close() throws Exception {
-        writer.close();
+        // Flush buffered bytes to the HDFS stream, then let the superclass halt the sync thread and
+        // run its final hsync()/ack while the stream is still open, and only then close the writer.
+        // Closing the writer first (the previous order) closed the stream before that final
+        // hsync(), throwing ClosedChannelException whenever unacked records remained at close time.
+        if (writer != null) {
+            writer.flush();
+        }
         super.close();
+        if (writer != null) {
+            writer.close();
+        }
     }
 
     @Override

--- a/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkIntegrationTest.java
+++ b/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkIntegrationTest.java
@@ -155,7 +155,7 @@ public class HdfsSinkIntegrationTest {
             }
 
             // Read the committed file back from the mini cluster's filesystem and assert it matches.
-            String actual = readSinkOutput();
+            String actual = readSinkOutput(DIRECTORY);
             Assert.assertEquals(actual, expected.toString(),
                     "content read back from HDFS must match what was written to the sink");
         } finally {
@@ -171,12 +171,62 @@ public class HdfsSinkIntegrationTest {
     }
 
     /**
-     * Reads and concatenates the content of every file produced by the sink under {@link #DIRECTORY}
-     * on the mini cluster's filesystem. The sink writes all records from a single {@code open()} into
-     * one file whose name starts with {@link #FILENAME_PREFIX}.
+     * Regression test for the close ordering bug: closing the sink while records are still unacked
+     * must flush and commit them, not throw. The old {@code writer.close()} before the superclass'
+     * final {@code hsync()} closed the stream first, so {@code hsync()} threw {@code
+     * ClosedChannelException} whenever the sync thread had not yet drained the queue at close time.
      */
-    private String readSinkOutput() throws Exception {
-        Path dir = new Path(DIRECTORY);
+    @Test(timeOut = 300_000)
+    public void testCloseWithUnackedRecordsCommitsInsteadOfThrowing() throws Exception {
+        String directory = "/hdfs-sink-close-ordering-test";
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            values.add("close-record-" + i);
+        }
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("hdfsConfigResources", coreSite.getAbsolutePath());
+        config.put("directory", directory);
+        config.put("filenamePrefix", FILENAME_PREFIX);
+        config.put("fileExtension", FILE_EXTENSION);
+        config.put("separator", SEPARATOR);
+        config.put("encoding", "UTF-8");
+        // A sync interval long enough that the background thread does not tick before we close()
+        // (writes take milliseconds), so close() runs the final hsync()/ack path with records still
+        // queued — the bug scenario. Kept modest because close() joins the sync thread, which sleeps
+        // this long before exiting.
+        config.put("syncInterval", 5_000L);
+
+        SinkContext sinkContext = mock(SinkContext.class);
+        AtomicInteger ackCount = new AtomicInteger(0);
+
+        HdfsStringSink sink = new HdfsStringSink();
+        sink.open(config, sinkContext);
+        for (String value : values) {
+            sink.write(mockRecord(value, ackCount));
+        }
+
+        // Under the old ordering this threw ClosedChannelException; it must now commit cleanly.
+        sink.close();
+
+        Assert.assertEquals(ackCount.get(), values.size(),
+                "close() should have flushed and acked every queued record");
+
+        StringBuilder expected = new StringBuilder();
+        for (String value : values) {
+            expected.append(value).append(SEPARATOR);
+        }
+        Assert.assertEquals(readSinkOutput(directory), expected.toString(),
+                "records written before close() must be committed to HDFS");
+    }
+
+    /**
+     * Reads and concatenates the content of every file the sink produced under {@code directory}
+     * on the mini cluster's filesystem, matching files whose name starts with
+     * {@link #FILENAME_PREFIX}.
+     */
+    private String readSinkOutput(String directory) throws Exception {
+        Path dir = new Path(directory);
         if (!clusterFs.exists(dir)) {
             return "";
         }

--- a/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkIntegrationTest.java
+++ b/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkIntegrationTest.java
@@ -192,32 +192,45 @@ public class HdfsSinkIntegrationTest {
         config.put("separator", SEPARATOR);
         config.put("encoding", "UTF-8");
         // A sync interval long enough that the background thread does not tick before we close()
-        // (writes take milliseconds), so close() runs the final hsync()/ack path with records still
-        // queued — the bug scenario. Kept modest because close() joins the sync thread, which sleeps
-        // this long before exiting.
-        config.put("syncInterval", 5_000L);
+        // (enqueuing the records takes milliseconds), so close() runs the final hsync()/ack path
+        // with records still queued — the bug scenario. Kept small because close() joins the sync
+        // thread, which sleeps this long before exiting, so it directly adds to the suite runtime.
+        config.put("syncInterval", 1_000L);
 
         SinkContext sinkContext = mock(SinkContext.class);
         AtomicInteger ackCount = new AtomicInteger(0);
 
         HdfsStringSink sink = new HdfsStringSink();
         sink.open(config, sinkContext);
-        for (String value : values) {
-            sink.write(mockRecord(value, ackCount));
+        boolean closed = false;
+        try {
+            for (String value : values) {
+                sink.write(mockRecord(value, ackCount));
+            }
+
+            // Under the old ordering this threw ClosedChannelException; it must now commit cleanly.
+            sink.close();
+            closed = true;
+
+            Assert.assertEquals(ackCount.get(), values.size(),
+                    "close() should have flushed and acked every queued record");
+
+            StringBuilder expected = new StringBuilder();
+            for (String value : values) {
+                expected.append(value).append(SEPARATOR);
+            }
+            Assert.assertEquals(readSinkOutput(directory), expected.toString(),
+                    "records written before close() must be committed to HDFS");
+        } finally {
+            if (!closed) {
+                // Failure path: close so the non-daemon HdfsSyncThread cannot outlive the test.
+                try {
+                    sink.close();
+                } catch (Exception e) {
+                    log.warn("Failed to close sink on the error path", e);
+                }
+            }
         }
-
-        // Under the old ordering this threw ClosedChannelException; it must now commit cleanly.
-        sink.close();
-
-        Assert.assertEquals(ackCount.get(), values.size(),
-                "close() should have flushed and acked every queued record");
-
-        StringBuilder expected = new StringBuilder();
-        for (String value : values) {
-            expected.append(value).append(SEPARATOR);
-        }
-        Assert.assertEquals(readSinkOutput(directory), expected.toString(),
-                "records written before close() must be committed to HDFS");
     }
 
     /**


### PR DESCRIPTION
Fixes #94

### Motivation

`HdfsAbstractTextFileSink.close()` closed the writer — and with it the underlying HDFS `FSDataOutputStream` — **before** the superclass ran its final flush:

```java
public void close() throws Exception {
    writer.close();     // closes the stream
    super.close();      // -> HdfsAbstractSink.close() -> syncThread.halt() -> ackRecords() -> stream.hsync()
}
```

`HdfsSyncThread.halt()` runs a final `ackRecords()`, which does `stream.hsync()` when any records are still unacked. Because `writer.close()` already closed that stream, the `hsync()` threw `ClosedChannelException` — so on shutdown with a non-empty unacked queue, the final batch was neither synced nor acked.

It only reproduces against real HDFS, which is why the existing mock-based sink tests (local filesystem, which does not throw on hsync-after-close) never caught it. Found while adding the HDFS integration test in #93, whose test sidesteps it by draining the queue before close.

### Modifications

Reorder `close()` so the final `hsync()`/ack happens while the stream is still open:

```java
if (writer != null) {
    writer.flush();     // push buffered bytes to the stream
}
super.close();          // halt sync thread; final hsync()/ack on the OPEN stream
if (writer != null) {
    writer.close();     // now close the stream
}
```

### Verifying this change

Added `testCloseWithUnackedRecordsCommitsInsteadOfThrowing` to `HdfsSinkIntegrationTest`: it writes records and closes immediately, with a long `syncInterval` so the background thread has not drained the queue — the exact bug scenario. Verified in both directions against the real MiniDFSCluster:

- **Old order** → `testCloseWithUnackedRecordsCommitsInsteadOfThrowing FAILED — java.nio.channels.ClosedChannelException`
- **Fixed order** → both integration tests `PASSED`, `BUILD SUCCESSFUL`

So the test genuinely guards the fix rather than passing alongside it.