### PR TITLE
[fix][io] Pin opentelemetry-semconv to a version the HBase client can use

### DIFF
--- a/hbase/build.gradle.kts
+++ b/hbase/build.gradle.kts
@@ -21,6 +21,15 @@ plugins {
     id("pulsar-connectors.java-conventions")
     id("pulsar-connectors.nar-conventions")
 }
+
+// hbase-client references io.opentelemetry.semconv.SemanticAttributes when building a trace span
+// on every table operation. That class was removed after the ~1.30 semconv line, but the shared
+// platform force-upgrades semconv to 1.37.0, so the sink throws NoClassDefFoundError on its first
+// HBase call. Drop the platform-managed version and pin the version hbase-client actually needs.
+pulsarConnectorsDependencies {
+    exclude(libs.opentelemetry.semconv)
+}
+
 dependencies {
     implementation(libs.pulsar.io.core)
     implementation(libs.pulsar.functions.instance)
@@ -30,4 +39,5 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.hbase.client)
     implementation(libs.hbase.common)
+    implementation("io.opentelemetry.semconv:opentelemetry-semconv:1.29.0-alpha")
 }


### PR DESCRIPTION
Fixes #101

### Motivation

The HBase sink throws `java.lang.NoClassDefFoundError: io/opentelemetry/semconv/SemanticAttributes` on its first table operation — it cannot write in a current build.

- The version catalog pins `opentelemetry-semconv = 1.37.0`.
- `hbase-client` 2.6.4 requests `semconv:1.29.0-alpha`, but the enforced platform force-upgrades it to 1.37.0 on `:hbase:runtimeClasspath`.
- `SemanticAttributes` was removed from semconv after the ~1.30 line — confirmed absent from the 1.37.0 jar.
- HBase references that class while building a trace span on **every** table op, so the missing class surfaces as `NoClassDefFoundError` on the first `put`/`get`/`createTable`.

Same shape as the Aerospike (#97) and Canal (#99) findings: compiles and packages fine, non-functional at runtime because the platform resolves a dependency the client library can't use. Found while attempting HBase integration coverage (#51).

### Modifications

```kotlin
pulsarConnectorsDependencies {
    exclude(libs.opentelemetry.semconv)
}
dependencies {
    // ...
    implementation("io.opentelemetry.semconv:opentelemetry-semconv:1.29.0-alpha")
}
```

### Verifying this change

```
# resolved semconv on :hbase:runtimeClasspath after the change:
io.opentelemetry.semconv:opentelemetry-semconv:1.29.0-alpha
# SemanticAttributes.class present in that jar: 1 (was 0 in 1.37.0)
```

Existing `:hbase:test` suite still passes. `:hbase:compileJava` clean.

### Caveat

Proven on the module's **resolved dependencies** — the class the sink needs is now on the classpath. Not yet verified against NAR classloading in a live Pulsar broker; the runtime write path is exercised by the integration test in #51, which is separately blocked on environment issues. This dependency fix stands on its own regardless.