### PR TITLE
[improve][test] Bound container startup in all Testcontainers tests

### DIFF
--- a/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraStringSinkTest.java
+++ b/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraStringSinkTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,8 @@ public class CassandraStringSinkTest {
 
     @BeforeMethod
     public void setUp() {
-        cassandraContainer = new CassandraContainer<>("cassandra:4.1");
+        cassandraContainer = new CassandraContainer<>("cassandra:4.1")
+                .withStartupTimeout(Duration.ofMinutes(3));
         cassandraContainer.start();
 
         // Create keyspace and table

--- a/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarSchemaHistoryTest.java
+++ b/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarSchemaHistoryTest.java
@@ -30,6 +30,7 @@ import io.debezium.relational.history.SchemaHistory;
 import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +65,8 @@ public class PulsarSchemaHistoryTest {
 
     @BeforeMethod
     protected void setup() throws Exception {
-        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE));
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE))
+                .withStartupTimeout(Duration.ofMinutes(5));
         pulsarContainer.start();
 
         pulsarClient = PulsarClient.builder()

--- a/debezium/mariadb/src/test/java/org/apache/pulsar/io/debezium/mariadb/DebeziumMariaDbSourceTest.java
+++ b/debezium/mariadb/src/test/java/org/apache/pulsar/io/debezium/mariadb/DebeziumMariaDbSourceTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertTrue;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -71,10 +72,12 @@ public class DebeziumMariaDbSourceTest {
                         "--binlog-format=ROW",
                         "--server-id=1"
                 )
-                .waitingFor(Wait.forLogMessage(".*ready for connections.*\\s", 2));
+                .waitingFor(Wait.forLogMessage(".*ready for connections.*\\s", 2))
+                .withStartupTimeout(Duration.ofMinutes(5));
         mariadbContainer.start();
 
-        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE));
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE))
+                .withStartupTimeout(Duration.ofMinutes(5));
         pulsarContainer.start();
 
         pulsarClient = PulsarClient.builder()

--- a/debezium/mongodb/src/test/java/org/apache/pulsar/io/debezium/mongodb/DebeziumMongoDbSourceTest.java
+++ b/debezium/mongodb/src/test/java/org/apache/pulsar/io/debezium/mongodb/DebeziumMongoDbSourceTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertNotNull;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -68,10 +69,12 @@ public class DebeziumMongoDbSourceTest {
         readerExecutor = Executors.newSingleThreadExecutor();
         // MongoDBContainer starts a single-node replica set, which Debezium requires
         // for change streams.
-        mongoContainer = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+        mongoContainer = new MongoDBContainer(DockerImageName.parse("mongo:7.0"))
+                .withStartupTimeout(Duration.ofMinutes(5));
         mongoContainer.start();
 
-        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE));
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE))
+                .withStartupTimeout(Duration.ofMinutes(5));
         pulsarContainer.start();
 
         pulsarClient = PulsarClient.builder()

--- a/debezium/mysql/src/test/java/org/apache/pulsar/io/debezium/mysql/DebeziumMysqlSourceTest.java
+++ b/debezium/mysql/src/test/java/org/apache/pulsar/io/debezium/mysql/DebeziumMysqlSourceTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertNotNull;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -86,10 +87,12 @@ readerExecutor = Executors.newSingleThreadExecutor(r -> {
                         "--gtid-mode=ON",
                         "--enforce-gtid-consistency=ON"
                 )
-                .waitingFor(Wait.forLogMessage(".*ready for connections.*\\s", 2));
+                .waitingFor(Wait.forLogMessage(".*ready for connections.*\\s", 2))
+                .withStartupTimeout(Duration.ofMinutes(5));
         mysqlContainer.start();
 
-        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE));
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE))
+                .withStartupTimeout(Duration.ofMinutes(5));
         pulsarContainer.start();
 
         pulsarClient = PulsarClient.builder()

--- a/debezium/postgres/src/test/java/org/apache/pulsar/io/debezium/postgres/DebeziumPostgresSourceTest.java
+++ b/debezium/postgres/src/test/java/org/apache/pulsar/io/debezium/postgres/DebeziumPostgresSourceTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertNotNull;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -72,10 +73,12 @@ public class DebeziumPostgresSourceTest {
                 .withCommand("postgres",
                         "-c", "wal_level=logical",
                         "-c", "max_wal_senders=4",
-                        "-c", "max_replication_slots=4");
+                        "-c", "max_replication_slots=4")
+                .withStartupTimeout(Duration.ofMinutes(5));
         postgresContainer.start();
 
-        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE));
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE))
+                .withStartupTimeout(Duration.ofMinutes(5));
         pulsarContainer.start();
 
         pulsarClient = PulsarClient.builder()

--- a/dynamodb/src/test/java/org/apache/pulsar/io/dynamodb/DynamoDBSourceIntegrationTest.java
+++ b/dynamodb/src/test/java/org/apache/pulsar/io/dynamodb/DynamoDBSourceIntegrationTest.java
@@ -37,6 +37,7 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.amazonaws.services.dynamodbv2.model.StreamSpecification;
 import com.amazonaws.services.dynamodbv2.model.StreamViewType;
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -82,7 +83,8 @@ public class DynamoDBSourceIntegrationTest {
             new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.0.3"))
                     .withServices(
                             LocalStackContainer.Service.DYNAMODB,
-                            LocalStackContainer.Service.CLOUDWATCH);
+                            LocalStackContainer.Service.CLOUDWATCH)
+                    .withStartupTimeout(Duration.ofMinutes(5));
 
     private AmazonDynamoDB dynamoDB;
     private String streamArn;

--- a/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkIntegrationTest.java
+++ b/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.io.influxdb.v1;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +96,8 @@ public class InfluxDBGenericRecordSinkIntegrationTest {
                 .withEnv("INFLUXDB_ADMIN_USER", USERNAME)
                 .withEnv("INFLUXDB_ADMIN_PASSWORD", PASSWORD)
                 .withEnv("INFLUXDB_HTTP_AUTH_ENABLED", "true")
-                .waitingFor(Wait.forHttp("/ping").forPort(INFLUXDB_PORT).forStatusCode(204));
+                .waitingFor(Wait.forHttp("/ping").forPort(INFLUXDB_PORT).forStatusCode(204))
+                .withStartupTimeout(Duration.ofMinutes(3));
         influxdbContainer.start();
 
         influxdbUrl = "http://" + influxdbContainer.getHost() + ":"

--- a/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkIntegrationTest.java
+++ b/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkIntegrationTest.java
@@ -24,6 +24,7 @@ import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.query.FluxRecord;
 import com.influxdb.query.FluxTable;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -98,7 +99,8 @@ public class InfluxDBSinkIntegrationTest {
                 .withEnv("DOCKER_INFLUXDB_INIT_ORG", ORG)
                 .withEnv("DOCKER_INFLUXDB_INIT_BUCKET", BUCKET)
                 .withEnv("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", TOKEN)
-                .waitingFor(Wait.forHttp("/health").forPort(INFLUXDB_PORT).forStatusCode(200));
+                .waitingFor(Wait.forHttp("/health").forPort(INFLUXDB_PORT).forStatusCode(200))
+                .withStartupTimeout(Duration.ofMinutes(3));
         influxdbContainer.start();
 
         influxdbUrl = "http://" + influxdbContainer.getHost() + ":"

--- a/jdbc/clickhouse/src/test/java/org/apache/pulsar/io/jdbc/ClickHouseJdbcSinkIntegrationTest.java
+++ b/jdbc/clickhouse/src/test/java/org/apache/pulsar/io/jdbc/ClickHouseJdbcSinkIntegrationTest.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -91,7 +92,8 @@ public class ClickHouseJdbcSinkIntegrationTest {
 
     @BeforeClass(alwaysRun = true)
     public void setUp() throws Exception {
-        clickhouse = new ClickHouseContainer(CLICKHOUSE_IMAGE);
+        clickhouse = new ClickHouseContainer(CLICKHOUSE_IMAGE)
+                .withStartupTimeout(Duration.ofMinutes(5));
         clickhouse.start();
 
         // Create the destination table over the HTTP interface (ClickHouse requires an explicit

--- a/jdbc/mariadb/src/test/java/org/apache/pulsar/io/jdbc/MariadbJdbcSinkIntegrationTest.java
+++ b/jdbc/mariadb/src/test/java/org/apache/pulsar/io/jdbc/MariadbJdbcSinkIntegrationTest.java
@@ -25,6 +25,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -82,7 +83,8 @@ public class MariadbJdbcSinkIntegrationTest {
 
     @BeforeClass(alwaysRun = true)
     public void setUp() throws Exception {
-        mariadb = new MariaDBContainer<>(MARIADB_IMAGE);
+        mariadb = new MariaDBContainer<>(MARIADB_IMAGE)
+                .withStartupTimeout(Duration.ofMinutes(3));
         mariadb.start();
 
         // Create the destination table over plain JDBC.

--- a/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -59,7 +60,8 @@ public class KinesisSinkTest {
     public static final LocalStackContainer LOCAL_STACK_CONTAINER =
             new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.0.3"))
                     .withServices(LocalStackContainer.Service.KINESIS, LocalStackContainer.Service.STS)
-                    .withEnv("KINESIS_PROVIDER", "kinesalite");
+                    .withEnv("KINESIS_PROVIDER", "kinesalite")
+                    .withStartupTimeout(Duration.ofMinutes(5));
 
     @BeforeClass(alwaysRun = true)
     public void beforeClass() throws Exception {

--- a/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkContainerTest.java
+++ b/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkContainerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,7 +51,8 @@ public class MongoSinkContainerTest {
 
     @BeforeMethod
     public void setUp() {
-        mongoContainer = new MongoDBContainer("mongo:6.0");
+        mongoContainer = new MongoDBContainer("mongo:6.0")
+                .withStartupTimeout(Duration.ofMinutes(3));
         mongoContainer.start();
         sink = new MongoSink();
     }

--- a/nsq/src/test/java/org/apache/pulsar/io/nsq/NSQSourceIntegrationTest.java
+++ b/nsq/src/test/java/org/apache/pulsar/io/nsq/NSQSourceIntegrationTest.java
@@ -32,6 +32,7 @@ import java.net.ServerSocket;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -106,7 +107,8 @@ public class NSQSourceIntegrationTest {
                 .withNetworkAliases("nsqlookupd")
                 .withCommand("/nsqlookupd")
                 .withExposedPorts(LOOKUPD_TCP_PORT, LOOKUPD_HTTP_PORT)
-                .waitingFor(Wait.forHttp("/ping").forPort(LOOKUPD_HTTP_PORT));
+                .waitingFor(Wait.forHttp("/ping").forPort(LOOKUPD_HTTP_PORT))
+                .withStartupTimeout(Duration.ofMinutes(3));
         nsqlookupd.start();
 
         nsqd = new GenericContainer<>(NSQ_IMAGE)
@@ -134,7 +136,8 @@ public class NSQSourceIntegrationTest {
                             Ports.Binding.bindPort(nsqdTcpPort));
                     hostConfig.withPortBindings(portBindings);
                 })
-                .waitingFor(Wait.forHttp("/ping").forPort(NSQD_HTTP_PORT));
+                .waitingFor(Wait.forHttp("/ping").forPort(NSQD_HTTP_PORT))
+                .withStartupTimeout(Duration.ofMinutes(3));
         nsqd.start();
 
         log.info("nsqlookupd http {}:{}, nsqd http {}:{}, nsqd tcp {}:{}",

--- a/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
+++ b/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.rabbitmq;
 
+import java.time.Duration;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -27,6 +28,7 @@ public class RabbitMQBrokerManager {
     public void startBroker() throws Exception {
         rabbitMQContainer = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.7.25-management-alpine"));
         rabbitMQContainer.withVhost("default");
+        rabbitMQContainer.withStartupTimeout(Duration.ofMinutes(3));
         rabbitMQContainer.start();
     }
 


### PR DESCRIPTION
## Motivation

A Testcontainers container started in `@BeforeClass`/`@BeforeMethod` with no `withStartupTimeout` hangs unbounded if the image pull or container start stalls. `@Test(timeOut=...)` does **not** help — it only bounds the test *method*, not the container start in `@BeforeClass`/`@BeforeMethod`. When a start stalls, the test hangs until the CI job's own 45-minute limit is reached, which has repeatedly cancelled unrelated PRs' CI runs (see #89, fixed for the MQTT sink in #91).

This PR applies the same fix to the remaining Testcontainers-based tests so a stuck container start fails fast instead of consuming the whole CI job.

## Modifications

Added `.withStartupTimeout(Duration.ofMinutes(N))` to every container instance (and `import java.time.Duration;` where missing). No test logic was changed — only the startup-timeout bound was added; all existing wait strategies, env, ports, network, etc. are preserved.

`N` values:
- **N = 3** — single normal container.
- **N = 5** — tests that start a DB container alongside a Pulsar container (the Debezium source tests), and large/slow images (ClickHouse, LocalStack, Pulsar).

| # | File | N |
|---|------|---|
| 1 | `cassandra/.../CassandraStringSinkTest.java` | 3 |
| 2 | `debezium/core/.../PulsarSchemaHistoryTest.java` (Pulsar) | 5 |
| 3 | `debezium/mariadb/.../DebeziumMariaDbSourceTest.java` (MariaDB + Pulsar) | 5, 5 |
| 4 | `debezium/mongodb/.../DebeziumMongoDbSourceTest.java` (Mongo + Pulsar) | 5, 5 |
| 5 | `debezium/mysql/.../DebeziumMysqlSourceTest.java` (MySQL + Pulsar) | 5, 5 |
| 6 | `debezium/postgres/.../DebeziumPostgresSourceTest.java` (Postgres + Pulsar) | 5, 5 |
| 7 | `dynamodb/.../DynamoDBSourceIntegrationTest.java` (LocalStack) | 5 |
| 8 | `influxdb/.../v1/InfluxDBGenericRecordSinkIntegrationTest.java` | 3 |
| 9 | `influxdb/.../v2/InfluxDBSinkIntegrationTest.java` | 3 |
| 10 | `jdbc/clickhouse/.../ClickHouseJdbcSinkIntegrationTest.java` (large image) | 5 |
| 11 | `jdbc/mariadb/.../MariadbJdbcSinkIntegrationTest.java` | 3 |
| 12 | `kinesis/.../KinesisSinkTest.java` (LocalStack) | 5 |
| 13 | `mongo/.../MongoSinkContainerTest.java` | 3 |
| 14 | `rabbitmq/.../RabbitMQBrokerManager.java` | 3 |
| 15 | `nsq/.../NSQSourceIntegrationTest.java` (nsqlookupd + nsqd) | 3, 3 |

All containers already had (or, via the specialized `*Container` classes, provide) a wait strategy, so no new wait strategy was needed.

## Verifying

`compileTestJava` succeeds for every touched module:

`:cassandra :debezium:pulsar-io-debezium-core :debezium:pulsar-io-debezium-mariadb :debezium:pulsar-io-debezium-mongodb :debezium:pulsar-io-debezium-mysql :debezium:pulsar-io-debezium-postgres :dynamodb :influxdb :jdbc:pulsar-io-jdbc-clickhouse :jdbc:pulsar-io-jdbc-mariadb :kinesis :mongo :rabbitmq :nsq` -> **BUILD SUCCESSFUL**.

`spotlessJavaCheck` on all touched modules -> **BUILD SUCCESSFUL** (license/format gate).

The two fast, reliable suites were run to confirm no regression:
- `:influxdb:test` -> all passed, including the container-backed `InfluxDBSinkIntegrationTest` (1) and `InfluxDBGenericRecordSinkIntegrationTest` (1); 0 failures.
- `:nsq:test` -> all passed, including the container-backed `NSQSourceIntegrationTest` (1); 0 failures.

The remaining container tests (Cassandra, Mongo, Kinesis, RabbitMQ, Debezium, ClickHouse) were not run locally, as they require amd64 emulation / are slow on arm64 — but the change only adds a startup-timeout bound and cannot alter a passing test's logic.
