### PR TITLE
[improve][io] Align the OpenMLDB module's forced protobuf with the platform version

### DIFF
--- a/jdbc/openmldb/build.gradle.kts
+++ b/jdbc/openmldb/build.gradle.kts
@@ -30,16 +30,19 @@ plugins {
 // - Curator: the SDK calls NodeCache.getListenable() expecting the 4.x signature (returning
 //   ListenerContainer); Curator 5.x changed it to return Listenable -> NoSuchMethodError on
 //   connect under the platform's 5.7.1.
-// - Protobuf: the SDK's generated classes (protoc 3.16) call makeExtensionsImmutable(), removed
-//   in protobuf-java 3.22 -> NoSuchMethodError on insert under the platform's 3.25.5. 3.21.12 is
-//   the newest runtime that still has it. (NARs never bundle protobuf — the Pulsar runtime
-//   provides it — so this only affects compile/test classpaths.)
+// - Protobuf: the SDK's generated classes (protoc 3.16) call makeExtensionsImmutable(), which
+//   protobuf-java 4.x removed (the 3.25.x line still has it). Without the force, the TEST
+//   classpath resolves protobuf 4.x by conflict resolution — io.kubernetes:client-java, a
+//   transitive of the test-only pulsar-functions-instance, requests it — and the SDK throws
+//   NoSuchMethodError on insert. Force the platform's 3.25.5: the same line the Pulsar runtime
+//   provides to the NAR in production (NARs never bundle protobuf), so the test matches what
+//   the connector actually runs against.
 configurations.all {
     resolutionStrategy.force(
         "org.apache.curator:curator-client:4.2.0",
         "org.apache.curator:curator-framework:4.2.0",
         "org.apache.curator:curator-recipes:4.2.0",
-        "com.google.protobuf:protobuf-java:3.21.12",
+        "com.google.protobuf:protobuf-java:3.25.5",
     )
 }
 


### PR DESCRIPTION
### Motivation

Follow-up to #105. That PR forced `protobuf-java` to 3.21.12 in the OpenMLDB module with a comment claiming `makeExtensionsImmutable()` was "removed in protobuf-java 3.22". While root-causing the same symptom in the Canal module (#98/#99), that claim was disproven empirically: the method survives through the entire 3.25.x line and was removed in protobuf-java **4.x**.

The `NoSuchMethodError` the force works around is actually caused by the **test** classpath resolving protobuf 4.x by conflict resolution — `io.kubernetes:client-java` (a transitive of the test-only `pulsar-functions-instance`) requests 4.29.3, outranking the platform's 3.25.5:

```
com.google.protobuf:protobuf-java:4.29.3
   Selection reasons:
      - By conflict resolution: between versions 4.29.3, 3.25.8, 3.25.5 and 3.16.3
+--- io.kubernetes:client-java:23.0.0
     \--- org.apache.pulsar:pulsar-functions-secrets:4.2.0
          \--- org.apache.pulsar:pulsar-functions-instance:4.2.0  (testImplementation)
```

### Modifications

Bump the forced version from 3.21.12 to **3.25.5** and correct the comment. 3.25.5 is the platform's pinned version and the same protobuf line the Pulsar runtime provides to the NAR in production (NARs never bundle protobuf), so the test classpath now matches what the connector actually runs against — and the module stops pinning to an older release than necessary.

### Verifying this change

Run on Linux x86-64 (Ubuntu 24.04, Docker 29.1.3, OpenJDK 21):

```
$ ./gradlew :jdbc:pulsar-io-jdbc-openmldb:test --rerun-tasks

Gradle suite > Gradle test > org.apache.pulsar.io.jdbc.OpenMLDBJdbcSinkIntegrationTest > testOpenWritesAndReadsBack PASSED

BUILD SUCCESSFUL in 1m 37s
```

### Documentation

- [x] `doc-not-needed` (build/test dependency alignment)
