### PR TITLE
[improve][test] KCA: re-enable broker tests (add buildtools + opentelemetry-sdk-testing)

### DIFF
--- a/kafka-connect-adaptor/build.gradle.kts
+++ b/kafka-connect-adaptor/build.gradle.kts
@@ -58,6 +58,11 @@ dependencies {
     // Provides TestRetrySupport, the base class of MockedPulsarServiceBaseTest /
     // ProducerConsumerBase used by the broker-backed tests below.
     testImplementation(libs.pulsar.buildtools)
+    // pulsar-broker's tests jar references io.opentelemetry.sdk.testing.assertj.* in method
+    // signatures; without this on the classpath, TestNG's getDeclaredMethods() call during test
+    // discovery throws NoClassDefFoundError and silently collects zero tests from every
+    // MockedPulsarServiceBaseTest subclass.
+    testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.56.0")
     testImplementation(libs.awaitility)
     testImplementation(libs.kafka.connect.file)
     testImplementation(libs.asynchttpclient)

--- a/kafka-connect-adaptor/build.gradle.kts
+++ b/kafka-connect-adaptor/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     testImplementation(variantOf(libs.pulsar.broker) { classifier("tests") })
     testImplementation(libs.pulsar.testmocks)
     // Provides TestRetrySupport, the base class of MockedPulsarServiceBaseTest /
-    // ProducerConsumerBase used by the broker-backed tests below.
+    // ProducerConsumerBase, which this module's broker-backed tests extend.
     testImplementation(libs.pulsar.buildtools)
     // pulsar-broker's tests jar references io.opentelemetry.sdk.testing.assertj.* in method
     // signatures; without this on the classpath, TestNG's getDeclaredMethods() call during test

--- a/kafka-connect-adaptor/build.gradle.kts
+++ b/kafka-connect-adaptor/build.gradle.kts
@@ -55,24 +55,12 @@ dependencies {
     testImplementation(libs.pulsar.broker)
     testImplementation(variantOf(libs.pulsar.broker) { classifier("tests") })
     testImplementation(libs.pulsar.testmocks)
+    // Provides TestRetrySupport, the base class of MockedPulsarServiceBaseTest /
+    // ProducerConsumerBase used by the broker-backed tests below.
+    testImplementation(libs.pulsar.buildtools)
     testImplementation(libs.awaitility)
     testImplementation(libs.kafka.connect.file)
     testImplementation(libs.asynchttpclient)
     testImplementation(libs.bc.fips)
     testImplementation(libs.netty.reactive.streams)
-}
-
-// Some KCA tests depend on pulsar-broker internals that have changed since the
-// last released version. Those tests will compile once matching pulsar artifacts
-// are published; exclude only them for now so that self-contained unit tests
-// still compile and run in CI.
-val brokerDependentTestSources = listOf(
-    "**/KafkaConnectSinkTest.java",
-    "**/KafkaConnectSourceErrRecTest.java",
-    "**/KafkaConnectSourceErrTest.java",
-    "**/KafkaConnectSourceTest.java",
-    "**/PulsarOffsetBackingStoreTest.java",
-)
-tasks.named<JavaCompile>("compileTestJava") {
-    exclude(brokerDependentTestSources)
 }

--- a/kafka-connect-adaptor/build.gradle.kts
+++ b/kafka-connect-adaptor/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     // signatures; without this on the classpath, TestNG's getDeclaredMethods() call during test
     // discovery throws NoClassDefFoundError and silently collects zero tests from every
     // MockedPulsarServiceBaseTest subclass.
-    testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.56.0")
+    testRuntimeOnly(libs.opentelemetry.sdk.testing)
     testImplementation(libs.awaitility)
     testImplementation(libs.kafka.connect.file)
     testImplementation(libs.asynchttpclient)


### PR DESCRIPTION
Fixes #118

### Motivation

The 5 broker-dependent Kafka Connect Adaptor test suites (`KafkaConnectSinkTest`, `KafkaConnectSourceTest`, `KafkaConnectSourceErrTest`, `KafkaConnectSourceErrRecTest`, `PulsarOffsetBackingStoreTest`) were excluded from compilation, leaving the connector's sink and source at **0% executed coverage**. The exclusion note claimed the tests were waiting for unreleased Pulsar artifacts — they were not.

### Two root causes, both in-repo

**1. Compilation** — the tests reference `TestRetrySupport` (root of `ProducerConsumerBase → MockedPulsarServiceBaseTest → TestRetrySupport`), which is published in `org.apache.pulsar:buildtools:4.2.0` but was never declared as a test dependency. Every earlier compile error was a cascade from that one missing supertype.

**2. Execution** — after they compiled, the tests still silently did not run: TestNG collected **zero** tests from every `MockedPulsarServiceBaseTest` subclass (no failures, no result XML, no broker startup — identical on macOS and Linux CI). TestNG's discovery calls `Class.getDeclaredMethods()` on each class in the hierarchy; on `MockedPulsarServiceBaseTest` that throws `NoClassDefFoundError: io/opentelemetry/sdk/testing/assertj/LongSumAssert`, because `opentelemetry-sdk-testing` (referenced by that class's method signatures) is `test`-scoped in pulsar-broker and not pulled transitively through the tests jar. TestNG swallows the error → 0 tests discovered. (`getMethods()`, public-only, does not throw, which is why it was easy to miss.)

### Modifications

- Add `testImplementation(libs.pulsar.buildtools)` — fixes compilation.
- Add `testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.56.0")` — fixes discovery/execution.
- Remove the `brokerDependentTestSources` compile exclusion.

### Verifying this change

```
$ ./gradlew :kafka-connect-adaptor:test
BUILD SUCCESSFUL

KafkaConnectSinkTest            45 tests, 0 failures
KafkaConnectSourceTest         12 tests, 0 failures
PulsarOffsetBackingStoreTest    5 tests, 0 failures
KafkaConnectSourceErrTest       1 test,  0 failures
KafkaConnectSourceErrRecTest    1 test,  0 failures
(plus the 2 unit suites already running)
= 99 tests total, 0 failures
```

Coverage on this module goes from 35 tests executing (~8.7% lines) to the full 99, restoring real coverage of `KafkaConnectSink` and `KafkaConnectSource`.

### Documentation

- [x] `doc-not-needed` (test-enablement change)
