### PR TITLE
Add ACL and TLS support to Redis sink

### DIFF
--- a/redis/src/main/java/org/apache/pulsar/io/redis/RedisAbstractConfig.java
+++ b/redis/src/main/java/org/apache/pulsar/io/redis/RedisAbstractConfig.java
@@ -51,10 +51,26 @@ public class RedisAbstractConfig implements Serializable {
     private String redisPassword;
 
     @FieldDoc(
+        required = false,
+        defaultValue = "",
+        sensitive = true,
+        help = "The username used for Redis 6+ ACL authentication. Requires redisPassword to also be set; "
+            + "if left blank, legacy password-only authentication is used instead")
+    private String redisUser;
+
+    @FieldDoc(
         required = true,
         defaultValue = "0",
         help = "The Redis database to connect to")
     private int redisDatabase = 0;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "false",
+        help = "Whether to enable TLS/SSL when connecting to Redis. Peer verification is always on and there is "
+            + "no way to configure a custom trust store, so only certificates trusted by the JVM's default "
+            + "trust store (e.g. public CA-signed certificates) are supported")
+    private boolean redisUseTls = false;
 
     @FieldDoc(
         required = false,
@@ -94,6 +110,8 @@ public class RedisAbstractConfig implements Serializable {
 
     public void validate() {
         Preconditions.checkNotNull(clientMode, "clientMode property not set.");
+        Preconditions.checkArgument(StringUtils.isBlank(redisUser) || !StringUtils.isBlank(redisPassword),
+            "redisPassword must be set when redisUser is set.");
     }
 
     public enum ClientMode {

--- a/redis/src/main/java/org/apache/pulsar/io/redis/RedisSession.java
+++ b/redis/src/main/java/org/apache/pulsar/io/redis/RedisSession.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.redis;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import io.lettuce.core.AbstractRedisClient;
@@ -123,14 +124,19 @@ public class RedisSession {
         return redisSession;
     }
 
-    private static List<RedisURI> redisURIs(List<HostAndPort> hostAndPorts, RedisSinkConfig config) {
+    @VisibleForTesting
+    static List<RedisURI> redisURIs(List<HostAndPort> hostAndPorts, RedisSinkConfig config) {
         List<RedisURI> redisURIs = Lists.newArrayList();
         for (HostAndPort hostAndPort : hostAndPorts) {
             RedisURI.Builder builder = RedisURI.builder();
             builder.withHost(hostAndPort.getHost());
             builder.withPort(hostAndPort.getPort());
             builder.withDatabase(config.getRedisDatabase());
-            if (!StringUtils.isBlank(config.getRedisPassword())) {
+            builder.withSsl(config.isRedisUseTls());
+            if (!StringUtils.isBlank(config.getRedisUser()) && !StringUtils.isBlank(config.getRedisPassword())) {
+                builder.withAuthentication(config.getRedisUser(), config.getRedisPassword());
+            } else if (!StringUtils.isBlank(config.getRedisPassword())) {
+                // authenticates as the "default" user
                 builder.withPassword(config.getRedisPassword());
             }
             redisURIs.add(builder.build());

--- a/redis/src/test/java/org/apache/pulsar/io/redis/RedisSessionTest.java
+++ b/redis/src/test/java/org/apache/pulsar/io/redis/RedisSessionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.redis;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import io.lettuce.core.RedisURI;
+import java.util.List;
+import org.apache.pulsar.io.redis.sink.RedisSinkConfig;
+import org.testng.annotations.Test;
+
+/**
+ * RedisSession test.
+ */
+@SuppressWarnings("deprecation")
+public class RedisSessionTest {
+
+    @Test
+    public final void legacyPasswordOnlyAuthTest() {
+        RedisSinkConfig config = new RedisSinkConfig();
+        config.setRedisHosts("localhost:6379");
+        config.setRedisPassword("fake@123");
+        config.setRedisDatabase(1);
+
+        RedisURI uri = buildSingleUri(config);
+        assertNull(uri.getUsername());
+        assertEquals(new String(uri.getPassword()), "fake@123");
+        assertFalse(uri.isSsl());
+        assertEquals(uri.getDatabase(), 1);
+    }
+
+    @Test
+    public final void aclAuthWithUserAndPasswordTest() {
+        RedisSinkConfig config = new RedisSinkConfig();
+        config.setRedisHosts("localhost:6379");
+        config.setRedisUser("fake-user");
+        config.setRedisPassword("fake@123");
+        config.setRedisDatabase(0);
+
+        RedisURI uri = buildSingleUri(config);
+        assertEquals(uri.getUsername(), "fake-user");
+        assertEquals(new String(uri.getPassword()), "fake@123");
+    }
+
+    @Test
+    public final void noAuthWhenNoCredentialsSetTest() {
+        RedisSinkConfig config = new RedisSinkConfig();
+        config.setRedisHosts("localhost:6379");
+        config.setRedisDatabase(0);
+
+        RedisURI uri = buildSingleUri(config);
+        assertNull(uri.getUsername());
+        assertNull(uri.getPassword());
+    }
+
+    @Test
+    public final void tlsDisabledByDefaultTest() {
+        RedisSinkConfig config = new RedisSinkConfig();
+        config.setRedisHosts("localhost:6379");
+        config.setRedisPassword("fake@123");
+
+        RedisURI uri = buildSingleUri(config);
+        assertFalse(uri.isSsl());
+    }
+
+    @Test
+    public final void tlsEnabledWhenConfiguredTest() {
+        RedisSinkConfig config = new RedisSinkConfig();
+        config.setRedisHosts("localhost:6379");
+        config.setRedisUser("fake-user");
+        config.setRedisPassword("fake@123");
+        config.setRedisUseTls(true);
+
+        RedisURI uri = buildSingleUri(config);
+        assertTrue(uri.isSsl());
+        assertEquals(uri.getUsername(), "fake-user");
+    }
+
+    private static RedisURI buildSingleUri(RedisSinkConfig config) {
+        List<RedisURI> uris = RedisSession.redisURIs(config.getHostAndPorts(), config);
+        assertEquals(uris.size(), 1);
+        return uris.get(0);
+    }
+}

--- a/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkConfigTest.java
+++ b/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkConfigTest.java
@@ -42,8 +42,10 @@ public class RedisSinkConfigTest {
         assertNotNull(config);
         assertEquals(config.getRedisHosts(), "localhost:6379");
         assertEquals(config.getRedisPassword(), "fake@123");
+        assertEquals(config.getRedisUser(), "fake-user");
         assertEquals(config.getRedisDatabase(), Integer.parseInt("1"));
         assertEquals(config.getClientMode(), "Standalone");
+        assertEquals(config.isRedisUseTls(), true);
         assertEquals(config.getOperationTimeout(), Long.parseLong("2000"));
         assertEquals(config.getBatchSize(), Integer.parseInt("100"));
         assertEquals(config.getBatchTimeMs(), Long.parseLong("1000"));
@@ -69,10 +71,52 @@ public class RedisSinkConfigTest {
         assertEquals(config.getRedisPassword(), "fake@123");
         assertEquals(config.getRedisDatabase(), Integer.parseInt("1"));
         assertEquals(config.getClientMode(), "Standalone");
+        assertEquals(config.isRedisUseTls(), false);
         assertEquals(config.getOperationTimeout(), Long.parseLong("2000"));
         assertEquals(config.getBatchSize(), Integer.parseInt("100"));
         assertEquals(config.getBatchTimeMs(), Long.parseLong("1000"));
         assertEquals(config.getConnectTimeout(), Long.parseLong("3000"));
+    }
+
+    @Test
+    public final void loadFromMapWithAclAndTlsTest() throws IOException {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("redisHosts", "localhost:6379");
+        map.put("redisUser", "fake-user");
+        map.put("redisPassword", "fake@123");
+        map.put("redisDatabase", "1");
+        map.put("clientMode", "Standalone");
+        map.put("redisUseTls", "true");
+        map.put("operationTimeout", "2000");
+        map.put("batchSize", "100");
+        map.put("batchTimeMs", "1000");
+        map.put("connectTimeout", "3000");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
+        assertNotNull(config);
+        assertEquals(config.getRedisUser(), "fake-user");
+        assertEquals(config.getRedisPassword(), "fake@123");
+        assertEquals(config.isRedisUseTls(), true);
+        config.validate();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "redisPassword must be set when redisUser is set.")
+    public final void redisUserWithoutPasswordFailsValidateTest() throws IOException {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("redisHosts", "localhost:6379");
+        map.put("redisUser", "fake-user");
+        map.put("redisDatabase", "1");
+        map.put("clientMode", "Standalone");
+        map.put("operationTimeout", "2000");
+        map.put("batchSize", "100");
+        map.put("batchTimeMs", "1000");
+        map.put("connectTimeout", "3000");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
+        config.validate();
     }
 
     @Test

--- a/redis/src/test/resources/sinkConfig.yaml
+++ b/redis/src/test/resources/sinkConfig.yaml
@@ -20,8 +20,10 @@
 {
 "redisHosts": "localhost:6379",
 "redisPassword": "fake@123",
+"redisUser": "fake-user",
 "redisDatabase": "1",
 "clientMode": "Standalone",
+"redisUseTls": "true",
 "operationTimeout": "2000",
 "batchSize": "100",
 "batchTimeMs": "1000",


### PR DESCRIPTION
## Motivation

The Redis connector currently supports password-only authentication but does not support Redis 6+ ACL authentication or TLS connections through the connector configuration.

## Modifications

- Add `redisUser` support for Redis ACL authentication.
- Preserve existing password-only authentication behavior.
- Add `redisUseTls` support for TLS connections.
- Validate that `redisPassword` is provided when `redisUser` is configured.
- Add unit tests for Redis URI authentication and TLS configuration.
- Document the current TLS trust-store limitation: custom trust-store/keystore configuration is not exposed by the connector.

## Tests

- `./gradlew :redis:check`