### PR TITLE
[feat][io] Add Aeron source connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mounting them into the `apachepulsar/pulsar` Docker image.
 ### Sources
 | Connector | Description |
 |-----------|-------------|
+| Aeron | Aeron UDP unicast/multicast and IPC transport |
 | Canal | MySQL binlog via Alibaba Canal |
 | Debezium (MySQL, MariaDB, PostgreSQL, MongoDB, MSSQL, Oracle) | CDC via Debezium |
 | DynamoDB | Amazon DynamoDB Streams |

--- a/aeron/build.gradle.kts
+++ b/aeron/build.gradle.kts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id("pulsar-connectors.java-conventions")
+    id("pulsar-connectors.nar-conventions")
+}
+dependencies {
+    implementation(libs.pulsar.io.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.commons.lang3)
+    // aeron-driver is required for the embedded media driver and depends on
+    // aeron-client, which brings agrona in transitively. Aeron is not provided by
+    // the function runtime, so it is bundled in the NAR.
+    implementation(libs.aeron.driver)
+    implementation(libs.aeron.client)
+
+    // The container test drives records into a real broker to prove the full path.
+    testImplementation(libs.testcontainers.pulsar)
+    testImplementation(libs.pulsar.client)
+    testImplementation(libs.pulsar.client.admin)
+}
+
+tasks.withType<Test>().configureEach {
+    // Aeron maps its control-and-command file into memory and spins on it. The default
+    // /dev/shm in CI containers is frequently too small for the driver's buffers, so
+    // tests pin the driver directory under the Gradle temp dir instead.
+    systemProperty("aeron.test.dir", layout.buildDirectory.dir("aeron-test").get().asFile.absolutePath)
+}

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronPoller.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronPoller.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+/**
+ * The unit of work owned by the source's polling thread.
+ *
+ * <p>This exists so {@link AeronSource} does not hard-code the plain-transport poll loop.
+ * An Aeron Archive backed implementation — replaying from a recorded position and
+ * checkpointing that position so restarts do not lose data — can be added later as a second
+ * implementation without reworking the source's lifecycle.
+ */
+public interface AeronPoller extends Runnable {
+
+    /**
+     * Signals the loop to finish. Returns without waiting; the caller joins the thread.
+     *
+     * <p>Must be safe to call from another thread and safe to call more than once.
+     */
+    void stop();
+}

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronPollingRunner.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronPollingRunner.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import io.aeron.FragmentAssembler;
+import io.aeron.Subscription;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.logbuffer.Header;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.IdleStrategy;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Polls an Aeron {@link Subscription} and hands each reassembled message to a consumer.
+ *
+ * <p>Aeron has no callback-driven delivery: a subscriber must poll, and the idle strategy
+ * decides what the thread does when there is nothing to read. One instance owns one thread.
+ */
+public class AeronPollingRunner implements AeronPoller {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AeronPollingRunner.class);
+
+    static final String METRIC_FRAGMENTS_RECEIVED = "aeron-fragments-received";
+    static final String METRIC_RECORDS_CONSUMED = "aeron-records-consumed";
+
+    private final Subscription subscription;
+    private final AeronSourceConfig config;
+    private final Consumer<Record<byte[]>> consumer;
+    private final SourceContext sourceContext;
+    private final IdleStrategy idleStrategy;
+
+    private volatile boolean running = true;
+
+    public AeronPollingRunner(Subscription subscription,
+                              AeronSourceConfig config,
+                              Consumer<Record<byte[]>> consumer,
+                              SourceContext sourceContext) {
+        this.subscription = subscription;
+        this.config = config;
+        this.consumer = consumer;
+        this.sourceContext = sourceContext;
+        this.idleStrategy = IdleStrategies.create(config.getIdleStrategy());
+    }
+
+    @Override
+    public void run() {
+        // FragmentAssembler stitches messages that were split across MTU-sized fragments and
+        // invokes the delegate once, with the whole message.
+        final FragmentHandler handler = this::onFragment;
+        final FragmentAssembler assembler = config.getFragmentAssemblyBufferLength() > 0
+                ? new FragmentAssembler(handler, config.getFragmentAssemblyBufferLength())
+                : new FragmentAssembler(handler);
+
+        LOG.info("Aeron poll loop started for channel {} stream {}",
+                config.getChannel(), config.getStreamId());
+        try {
+            while (running) {
+                final int fragments = subscription.poll(assembler, config.getFragmentLimit());
+                if (fragments > 0) {
+                    // Counted here rather than in the handler: poll() returns wire-level
+                    // fragments, whereas the assembler invokes the handler once per whole
+                    // message. Comparing the two metrics is what shows how much traffic is
+                    // arriving fragmented.
+                    recordMetric(METRIC_FRAGMENTS_RECEIVED, fragments);
+                }
+                idleStrategy.idle(fragments);
+            }
+        } catch (Throwable t) {
+            // Never let the poll loop die silently; without this the source would look
+            // healthy while delivering nothing.
+            if (running) {
+                LOG.error("Aeron poll loop for channel {} stream {} terminated unexpectedly",
+                        config.getChannel(), config.getStreamId(), t);
+            }
+        } finally {
+            LOG.info("Aeron poll loop stopped for channel {} stream {}",
+                    config.getChannel(), config.getStreamId());
+        }
+    }
+
+    /**
+     * Handles one reassembled Aeron message.
+     *
+     * <p>The {@code buffer} is a window onto an Aeron term buffer that Aeron reuses as soon
+     * as this method returns. The payload copy below is therefore mandatory, not defensive:
+     * without it the record handed downstream would mutate under the consumer and produce
+     * intermittent, load-dependent corruption rather than a clean failure.
+     */
+    // Package-private so AeronPollingRunnerTest can assert the copy semantics directly,
+    // without standing up a media driver.
+    void onFragment(DirectBuffer buffer, int offset, int length, Header header) {
+        final byte[] payload = new byte[length];
+        buffer.getBytes(offset, payload);
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(AeronRecord.PROP_SESSION_ID, Integer.toString(header.sessionId()));
+        properties.put(AeronRecord.PROP_STREAM_ID, Integer.toString(header.streamId()));
+        properties.put(AeronRecord.PROP_CHANNEL, config.getChannel());
+        properties.put(AeronRecord.PROP_POSITION, Long.toString(header.position()));
+        properties.put(AeronRecord.PROP_INGEST_TS, Long.toString(System.currentTimeMillis()));
+
+        final String key = config.isKeyBySessionId() ? Integer.toString(header.sessionId()) : null;
+
+        // consume() blocks once the source's internal queue is full. That block is the
+        // backpressure mechanism: the poll loop stops polling, and Aeron flow control pushes
+        // back on unicast publishers. Multicast publishers are not slowed and the
+        // subscription will fall behind, which is a documented at-most-once loss window.
+        consumer.accept(new AeronRecord(payload, key, properties));
+        recordMetric(METRIC_RECORDS_CONSUMED, 1);
+    }
+
+    private void recordMetric(String name, int count) {
+        if (sourceContext != null) {
+            sourceContext.recordMetric(name, count);
+        }
+    }
+
+    @Override
+    public void stop() {
+        running = false;
+    }
+}

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronRecord.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronRecord.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.pulsar.functions.api.Record;
+
+/**
+ * A {@link Record} carrying one reassembled Aeron message together with the Aeron
+ * header metadata it arrived with.
+ *
+ * <p>The payload is a private copy taken while the Aeron fragment handler callback was on
+ * the stack: Aeron hands out a view into a term buffer that it reuses as soon as the
+ * callback returns, so the bytes must be copied before the record leaves the polling
+ * thread. See {@link AeronPollingRunner}.
+ *
+ * <p>{@link #ack()} and {@link #fail()} are deliberately no-ops. Plain Aeron is a transport
+ * with no persistence and no resumable position, so there is nothing to acknowledge and
+ * nothing to redeliver. This is what makes the connector at-most-once.
+ */
+public class AeronRecord implements Record<byte[]> {
+
+    public static final String PROP_SESSION_ID = "aeron.session-id";
+    public static final String PROP_STREAM_ID = "aeron.stream-id";
+    public static final String PROP_CHANNEL = "aeron.channel";
+    public static final String PROP_POSITION = "aeron.position";
+    public static final String PROP_INGEST_TS = "aeron.ingest-ts";
+
+    private final byte[] value;
+    private final String key;
+    private final Map<String, String> properties;
+
+    /**
+     * @param value      the reassembled payload; must already be a copy owned by this record
+     * @param key        the record key, or null for none
+     * @param properties Aeron metadata; copied defensively
+     */
+    public AeronRecord(byte[] value, String key, Map<String, String> properties) {
+        this.value = value;
+        this.key = key;
+        this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    }
+
+    @Override
+    public Optional<String> getKey() {
+        return Optional.ofNullable(key);
+    }
+
+    @Override
+    public byte[] getValue() {
+        return value;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public void ack() {
+        // No-op: see class javadoc. Plain Aeron has nothing to acknowledge.
+    }
+
+    @Override
+    public void fail() {
+        // No-op: see class javadoc. Plain Aeron cannot redeliver a message.
+    }
+}

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronSource.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronSource.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import io.aeron.Aeron;
+import io.aeron.Subscription;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.io.core.PushSource;
+import org.apache.pulsar.io.core.SourceContext;
+import org.apache.pulsar.io.core.annotations.Connector;
+import org.apache.pulsar.io.core.annotations.IOType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A source connector that subscribes to an Aeron channel and publishes each message to a
+ * Pulsar topic.
+ *
+ * <p>This is a {@link PushSource} rather than a plain {@code Source} because Aeron delivers
+ * only to a caller that polls: a dedicated thread runs the poll loop and pushes into the
+ * source's internal queue, which the function framework drains via {@code read()}.
+ *
+ * <p><b>Delivery semantics: at-most-once.</b> Plain Aeron is a transport with no persistence
+ * and no resumable position, so nothing can be replayed. Messages are lost across connector
+ * restarts, and a multicast subscriber that falls behind loses data once the publisher's term
+ * buffer rotates. Lossless ingestion needs Aeron Archive, which {@link AeronPoller} leaves
+ * room for but this implementation does not provide.
+ *
+ * <p>A single instance owns one subscription; parallelism greater than 1 would give every
+ * instance the same full stream rather than partitioning it.
+ */
+@Connector(
+        name = "aeron",
+        type = IOType.SOURCE,
+        help = "An Aeron source connector that bridges an Aeron subscription into a Pulsar topic",
+        configClass = AeronSourceConfig.class)
+public class AeronSource extends PushSource<byte[]> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AeronSource.class);
+
+    private static final long POLLER_JOIN_TIMEOUT_MS = 5_000L;
+
+    private MediaDriver mediaDriver;
+    private Aeron aeron;
+    private Subscription subscription;
+    private AeronPoller poller;
+    private Thread pollerThread;
+
+    @Override
+    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+        final AeronSourceConfig aeronSourceConfig = AeronSourceConfig.load(config);
+        aeronSourceConfig.validate();
+
+        try {
+            String aeronDirectoryName = aeronSourceConfig.getAeronDirectoryName();
+
+            if (aeronSourceConfig.isUseEmbeddedMediaDriver()) {
+                final MediaDriver.Context driverContext = new MediaDriver.Context()
+                        // SHARED runs the driver's duties on one thread. A connector is not
+                        // chasing single-digit-microsecond latency, and this keeps the core
+                        // count down in the containers connectors usually run in.
+                        .threadingMode(ThreadingMode.SHARED)
+                        .dirDeleteOnStart(true)
+                        .dirDeleteOnShutdown(true);
+                if (StringUtils.isNotBlank(aeronDirectoryName)) {
+                    driverContext.aeronDirectoryName(aeronDirectoryName);
+                }
+                mediaDriver = MediaDriver.launchEmbedded(driverContext);
+                // launchEmbedded generates a unique directory when one was not supplied, so
+                // read it back rather than assuming the configured value.
+                aeronDirectoryName = mediaDriver.aeronDirectoryName();
+                LOG.info("Launched embedded Aeron media driver in {}", aeronDirectoryName);
+            }
+
+            final Aeron.Context aeronContext = new Aeron.Context();
+            if (StringUtils.isNotBlank(aeronDirectoryName)) {
+                aeronContext.aeronDirectoryName(aeronDirectoryName);
+            }
+            aeron = Aeron.connect(aeronContext);
+
+            subscription = aeron.addSubscription(
+                    aeronSourceConfig.getChannel(), aeronSourceConfig.getStreamId());
+
+            poller = new AeronPollingRunner(subscription, aeronSourceConfig, this::consume, sourceContext);
+            // A dedicated thread, not a shared pool: the loop runs until close() and would
+            // otherwise occupy a pool thread indefinitely.
+            pollerThread = new Thread(poller, threadName(sourceContext));
+            pollerThread.setDaemon(true);
+            pollerThread.start();
+
+            LOG.info("Aeron source subscribed to channel {} stream {}",
+                    aeronSourceConfig.getChannel(), aeronSourceConfig.getStreamId());
+        } catch (Exception e) {
+            // open() failing part-way would otherwise leak a media driver process and its
+            // directory, since the framework does not call close() on a failed open().
+            closeQuietly();
+            throw e;
+        }
+    }
+
+    private static String threadName(SourceContext sourceContext) {
+        if (sourceContext == null) {
+            return "aeron-source-poller";
+        }
+        return "aeron-source-poller-" + sourceContext.getSourceName() + "-" + sourceContext.getInstanceId();
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeQuietly();
+    }
+
+    /**
+     * Tears down in reverse order of construction: stop polling first so nothing touches the
+     * subscription while it is being closed.
+     */
+    private void closeQuietly() {
+        if (poller != null) {
+            poller.stop();
+        }
+        if (pollerThread != null) {
+            try {
+                pollerThread.join(POLLER_JOIN_TIMEOUT_MS);
+                if (pollerThread.isAlive()) {
+                    // The loop can be parked inside a blocking consume() when the downstream
+                    // queue is full. Interrupt so shutdown is not held hostage by it.
+                    LOG.warn("Aeron poll thread did not stop within {} ms; interrupting",
+                            POLLER_JOIN_TIMEOUT_MS);
+                    pollerThread.interrupt();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            pollerThread = null;
+        }
+        poller = null;
+
+        if (subscription != null) {
+            try {
+                subscription.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close Aeron subscription", e);
+            }
+            subscription = null;
+        }
+        if (aeron != null) {
+            try {
+                aeron.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close Aeron client", e);
+            }
+            aeron = null;
+        }
+        if (mediaDriver != null) {
+            try {
+                // Configured with dirDeleteOnShutdown, so this also removes the directory.
+                mediaDriver.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close embedded Aeron media driver", e);
+            }
+            mediaDriver = null;
+        }
+    }
+}

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronSource.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronSource.java
@@ -146,6 +146,14 @@ public class AeronSource extends PushSource<byte[]> {
                     LOG.warn("Aeron poll thread did not stop within {} ms; interrupting",
                             POLLER_JOIN_TIMEOUT_MS);
                     pollerThread.interrupt();
+                    // Wait again rather than falling straight through: closing the
+                    // subscription while the loop is still inside poll() races with Aeron's
+                    // own teardown and surfaces as spurious exceptions during shutdown.
+                    pollerThread.join(POLLER_JOIN_TIMEOUT_MS);
+                    if (pollerThread.isAlive()) {
+                        LOG.warn("Aeron poll thread still alive after interrupt; "
+                                + "closing the subscription anyway");
+                    }
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronSourceConfig.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/AeronSourceConfig.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.aeron.ChannelUri;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.io.core.annotations.FieldDoc;
+
+/**
+ * Aeron Source Connector Config.
+ */
+@Data
+@Accessors(chain = true)
+public class AeronSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @FieldDoc(
+            required = true,
+            defaultValue = "",
+            help = "The Aeron channel URI to subscribe to, for example "
+                    + "'aeron:udp?endpoint=0.0.0.0:40123' or 'aeron:ipc'")
+    private String channel;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "1001",
+            help = "The Aeron stream id to subscribe to within the channel. Must not be 0")
+    private int streamId = 1001;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "true",
+            help = "Whether to launch an embedded Aeron media driver. When false, "
+                    + "'aeronDirectoryName' must point at the directory of an externally "
+                    + "managed media driver")
+    private boolean useEmbeddedMediaDriver = true;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "The Aeron media driver directory. Required when "
+                    + "'useEmbeddedMediaDriver' is false; optional otherwise, in which case "
+                    + "the embedded driver picks its own directory")
+    private String aeronDirectoryName;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "backoff",
+            help = "The idle strategy used by the polling thread when no fragments are "
+                    + "available. Supported values are 'backoff', 'sleeping', 'yielding' "
+                    + "and 'busyspin'. 'busyspin' gives the lowest latency but pins a core")
+    private String idleStrategy = IdleStrategies.BACKOFF;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "256",
+            help = "The maximum number of fragments to read in a single poll")
+    private int fragmentLimit = 256;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "When true, the record key is set to the Aeron session id, which lets "
+                    + "key_shared subscriptions and topic compaction group by Aeron session")
+    private boolean keyBySessionId = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "0",
+            help = "Initial buffer length, in bytes, used by the fragment assembler for "
+                    + "reassembling messages larger than the MTU. 0 uses the Aeron default")
+    private int fragmentAssemblyBufferLength = 0;
+
+    public static AeronSourceConfig load(Map<String, Object> map) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(mapper.writeValueAsString(map), AeronSourceConfig.class);
+    }
+
+    public static AeronSourceConfig load(String yamlFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        return mapper.readValue(new File(yamlFile), AeronSourceConfig.class);
+    }
+
+    /**
+     * Validates the configuration, failing fast at {@code open()} time rather than letting
+     * a bad channel URI surface later as an obscure Aeron driver error.
+     *
+     * @throws IllegalArgumentException if any value is missing or unusable
+     */
+    public void validate() {
+        if (StringUtils.isBlank(channel)) {
+            throw new IllegalArgumentException("channel must be set");
+        }
+        try {
+            ChannelUri.parse(channel);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("channel is not a valid Aeron URI: " + channel, e);
+        }
+        // Aeron reserves stream id 0, so a 0 here is nearly always an unset field rather
+        // than a deliberate choice.
+        if (streamId == 0) {
+            throw new IllegalArgumentException("streamId must not be 0");
+        }
+        if (!IdleStrategies.isSupported(idleStrategy)) {
+            throw new IllegalArgumentException("idleStrategy must be one of "
+                    + IdleStrategies.supportedStrategies() + " but was: " + idleStrategy);
+        }
+        if (fragmentLimit <= 0) {
+            throw new IllegalArgumentException("fragmentLimit must be positive but was: " + fragmentLimit);
+        }
+        if (fragmentAssemblyBufferLength < 0) {
+            throw new IllegalArgumentException(
+                    "fragmentAssemblyBufferLength must not be negative but was: " + fragmentAssemblyBufferLength);
+        }
+        // Without an embedded driver there is nothing to point the Aeron client at unless
+        // the caller names the external driver's directory.
+        if (!useEmbeddedMediaDriver && StringUtils.isBlank(aeronDirectoryName)) {
+            throw new IllegalArgumentException(
+                    "aeronDirectoryName must be set when useEmbeddedMediaDriver is false");
+        }
+    }
+}

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/IdleStrategies.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/IdleStrategies.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.io.aeron;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +42,9 @@ public final class IdleStrategies {
     public static final String YIELDING = "yielding";
     public static final String BUSYSPIN = "busyspin";
 
-    private static final List<String> SUPPORTED = Arrays.asList(BACKOFF, SLEEPING, YIELDING, BUSYSPIN);
+    // Immutable: supportedStrategies() hands this straight out, and a caller mutating it
+    // would silently change what isSupported()/create() accept.
+    private static final List<String> SUPPORTED = List.of(BACKOFF, SLEEPING, YIELDING, BUSYSPIN);
 
     // Agrona's conventional backoff defaults: spin, then yield, then park between 1us and 1ms.
     private static final long BACKOFF_MAX_SPINS = 100L;

--- a/aeron/src/main/java/org/apache/pulsar/io/aeron/IdleStrategies.java
+++ b/aeron/src/main/java/org/apache/pulsar/io/aeron/IdleStrategies.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.agrona.concurrent.BackoffIdleStrategy;
+import org.agrona.concurrent.BusySpinIdleStrategy;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.SleepingMillisIdleStrategy;
+import org.agrona.concurrent.YieldingIdleStrategy;
+
+/**
+ * Maps the {@code idleStrategy} config value onto an Agrona {@link IdleStrategy}.
+ *
+ * <p>The choice trades latency against CPU. {@code busyspin} never yields the core and gives
+ * the lowest latency; {@code sleeping} parks the thread and is the cheapest. {@code backoff}
+ * is the default because it spins briefly then degrades to parking, which behaves acceptably
+ * both on a busy stream and on an idle one.
+ */
+public final class IdleStrategies {
+
+    public static final String BACKOFF = "backoff";
+    public static final String SLEEPING = "sleeping";
+    public static final String YIELDING = "yielding";
+    public static final String BUSYSPIN = "busyspin";
+
+    private static final List<String> SUPPORTED = Arrays.asList(BACKOFF, SLEEPING, YIELDING, BUSYSPIN);
+
+    // Agrona's conventional backoff defaults: spin, then yield, then park between 1us and 1ms.
+    private static final long BACKOFF_MAX_SPINS = 100L;
+    private static final long BACKOFF_MAX_YIELDS = 10L;
+    private static final long BACKOFF_MIN_PARK_NS = 1_000L;
+    private static final long BACKOFF_MAX_PARK_NS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private static final long SLEEP_PERIOD_MS = 1L;
+
+    private IdleStrategies() {
+    }
+
+    /**
+     * @return the strategy names accepted by {@link #create(String)}
+     */
+    public static List<String> supportedStrategies() {
+        return SUPPORTED;
+    }
+
+    public static boolean isSupported(String name) {
+        return name != null && SUPPORTED.contains(name.toLowerCase(Locale.ROOT).trim());
+    }
+
+    /**
+     * Creates a new {@link IdleStrategy}. Strategies are stateful, so each polling thread
+     * must be given its own instance.
+     *
+     * @throws IllegalArgumentException if the name is not recognised
+     */
+    public static IdleStrategy create(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("idleStrategy must not be null");
+        }
+        switch (name.toLowerCase(Locale.ROOT).trim()) {
+            case BACKOFF:
+                return new BackoffIdleStrategy(
+                        BACKOFF_MAX_SPINS, BACKOFF_MAX_YIELDS, BACKOFF_MIN_PARK_NS, BACKOFF_MAX_PARK_NS);
+            case SLEEPING:
+                return new SleepingMillisIdleStrategy(SLEEP_PERIOD_MS);
+            case YIELDING:
+                return new YieldingIdleStrategy();
+            case BUSYSPIN:
+                return new BusySpinIdleStrategy();
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown idleStrategy '" + name + "', expected one of " + SUPPORTED);
+        }
+    }
+}

--- a/aeron/src/main/java/package-info.java
+++ b/aeron/src/main/java/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */

--- a/aeron/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/aeron/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: aeron
+description: Aeron Source Connector
+sourceClass: org.apache.pulsar.io.aeron.AeronSource
+sourceConfigClass: org.apache.pulsar.io.aeron.AeronSourceConfig

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronPollingRunnerTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronPollingRunnerTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import io.aeron.logbuffer.Header;
+import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.protocol.DataHeaderFlyweight;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the fragment-handling half of {@link AeronPollingRunner} without standing up a
+ * media driver, by handing it a hand-built Aeron data frame.
+ */
+public class AeronPollingRunnerTest {
+
+    private static final String CHANNEL = "aeron:ipc";
+    private static final int STREAM_ID = 1001;
+    private static final int SESSION_ID = 77;
+    private static final int TERM_LENGTH = 64 * 1024;
+
+    private List<Record<byte[]>> consumed;
+    private SourceContext sourceContext;
+
+    @BeforeMethod
+    public void setUp() {
+        consumed = new ArrayList<>();
+        sourceContext = mock(SourceContext.class);
+    }
+
+    private AeronPollingRunner newRunner(AeronSourceConfig config) {
+        // The subscription is only touched by run(); these tests drive onFragment directly.
+        return new AeronPollingRunner(null, config, consumed::add, sourceContext);
+    }
+
+    private static AeronSourceConfig config() {
+        return new AeronSourceConfig().setChannel(CHANNEL).setStreamId(STREAM_ID);
+    }
+
+    /**
+     * Builds a real Aeron data frame: a {@link Header} is final and reads its fields straight
+     * out of the buffer it is attached to, so the frame has to be genuine rather than mocked.
+     *
+     * @return the frame buffer; the payload starts at {@link DataHeaderFlyweight#HEADER_LENGTH}
+     */
+    private static UnsafeBuffer frameWith(byte[] payload, Header header) {
+        UnsafeBuffer frame = new UnsafeBuffer(new byte[DataHeaderFlyweight.HEADER_LENGTH + payload.length]);
+        DataHeaderFlyweight flyweight = new DataHeaderFlyweight(frame);
+        flyweight.frameLength(DataHeaderFlyweight.HEADER_LENGTH + payload.length);
+        flyweight.sessionId(SESSION_ID);
+        flyweight.streamId(STREAM_ID);
+        flyweight.termId(0);
+        flyweight.termOffset(0);
+        frame.putBytes(DataHeaderFlyweight.HEADER_LENGTH, payload);
+
+        header.buffer(frame);
+        header.offset(0);
+        return frame;
+    }
+
+    private static Header newHeader() {
+        return new Header(0, LogBufferDescriptor.positionBitsToShift(TERM_LENGTH));
+    }
+
+    @Test
+    public void testPayloadIsCopiedOutOfTheTermBuffer() {
+        // The whole point of the copy in onFragment: Aeron reuses term buffers as soon as the
+        // callback returns. Without the copy this record's value would change underneath the
+        // consumer. Simulating that reuse here is the only cheap way to catch a regression.
+        byte[] payload = "original-payload".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        byte[] overwrite = "CLOBBEREDCLOBBERE".substring(0, payload.length)
+                .getBytes(StandardCharsets.UTF_8);
+        frame.putBytes(DataHeaderFlyweight.HEADER_LENGTH, overwrite);
+
+        assertThat(consumed).hasSize(1);
+        assertThat(new String(consumed.get(0).getValue(), StandardCharsets.UTF_8))
+                .isEqualTo("original-payload");
+    }
+
+    @Test
+    public void testOnlyTheFragmentRangeIsCopied() {
+        // A fragment is a window into a larger frame; copying the whole buffer would smear
+        // the header (and any neighbouring fragment) into the payload.
+        byte[] payload = "abcdefghij".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        assertThat(consumed.get(0).getValue()).isEqualTo(payload);
+        assertThat(consumed.get(0).getValue()).hasSize(payload.length);
+    }
+
+    @Test
+    public void testZeroLengthFragmentProducesEmptyPayload() {
+        byte[] payload = new byte[0];
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, 0, header);
+
+        assertThat(consumed).hasSize(1);
+        assertThat(consumed.get(0).getValue()).isEmpty();
+    }
+
+    @Test
+    public void testMetadataIsTakenFromTheAeronHeader() {
+        byte[] payload = "x".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+        long expectedPosition = header.position();
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        assertThat(consumed.get(0).getProperties())
+                .containsEntry(AeronRecord.PROP_SESSION_ID, Integer.toString(SESSION_ID))
+                .containsEntry(AeronRecord.PROP_STREAM_ID, Integer.toString(STREAM_ID))
+                .containsEntry(AeronRecord.PROP_CHANNEL, CHANNEL)
+                .containsEntry(AeronRecord.PROP_POSITION, Long.toString(expectedPosition))
+                .containsKey(AeronRecord.PROP_INGEST_TS);
+    }
+
+    @Test
+    public void testNoKeyUnlessKeyBySessionIdIsSet() {
+        byte[] payload = "x".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        assertThat(consumed.get(0).getKey()).isEmpty();
+    }
+
+    @Test
+    public void testKeyBySessionIdSetsTheRecordKey() {
+        byte[] payload = "x".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config().setKeyBySessionId(true))
+                .onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        assertThat(consumed.get(0).getKey()).contains(Integer.toString(SESSION_ID));
+    }
+
+    @Test
+    public void testEachAssembledMessageCountsAsOneRecord() {
+        byte[] payload = "x".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        verify(sourceContext).recordMetric(eq(AeronPollingRunner.METRIC_RECORDS_CONSUMED), eq(1.0d));
+        // The fragment counter belongs to the poll loop, not the handler: the assembler calls
+        // the handler once per whole message, so counting fragments here would under-report
+        // every message that arrived split across the MTU.
+        verify(sourceContext, never())
+                .recordMetric(eq(AeronPollingRunner.METRIC_FRAGMENTS_RECEIVED), anyDouble());
+    }
+
+    @Test
+    public void testEachFragmentGetsItsOwnPayloadArray() {
+        Header header = newHeader();
+        byte[] first = "first".getBytes(StandardCharsets.UTF_8);
+        UnsafeBuffer frame = frameWith(first, header);
+        AeronPollingRunner runner = newRunner(config());
+
+        runner.onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, first.length, header);
+        runner.onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, first.length, header);
+
+        assertThat(consumed).hasSize(2);
+        assertThat(consumed.get(0).getValue()).isNotSameAs(consumed.get(1).getValue());
+    }
+
+    @Test
+    public void testStopIsIdempotent() {
+        AeronPollingRunner runner = newRunner(config());
+
+        runner.stop();
+        runner.stop();
+    }
+
+    @Test
+    public void testNullSourceContextIsTolerated() {
+        // localrun and unit harnesses can hand the source a null context; metric recording
+        // must not be the thing that breaks the pipeline.
+        byte[] payload = "x".getBytes(StandardCharsets.UTF_8);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        new AeronPollingRunner(null, config(), consumed::add, null)
+                .onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        assertThat(consumed).hasSize(1);
+    }
+
+    @Test
+    public void testLargePayloadIsCopiedIntact() {
+        byte[] payload = new byte[8192];
+        Arrays.fill(payload, (byte) 0x5A);
+        Header header = newHeader();
+        UnsafeBuffer frame = frameWith(payload, header);
+
+        newRunner(config()).onFragment(frame, DataHeaderFlyweight.HEADER_LENGTH, payload.length, header);
+
+        assertThat(consumed.get(0).getValue()).isEqualTo(payload);
+    }
+}

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronRecordTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronRecordTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link AeronRecord} metadata exposure.
+ */
+public class AeronRecordTest {
+
+    private static Map<String, String> properties() {
+        Map<String, String> props = new HashMap<>();
+        props.put(AeronRecord.PROP_SESSION_ID, "42");
+        props.put(AeronRecord.PROP_STREAM_ID, "1001");
+        props.put(AeronRecord.PROP_CHANNEL, "aeron:ipc");
+        props.put(AeronRecord.PROP_POSITION, "4096");
+        props.put(AeronRecord.PROP_INGEST_TS, "1754870400000");
+        return props;
+    }
+
+    @Test
+    public void testValueAndProperties() {
+        byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+
+        AeronRecord record = new AeronRecord(payload, null, properties());
+
+        assertThat(record.getValue()).isEqualTo(payload);
+        assertThat(record.getProperties())
+                .containsEntry(AeronRecord.PROP_SESSION_ID, "42")
+                .containsEntry(AeronRecord.PROP_STREAM_ID, "1001")
+                .containsEntry(AeronRecord.PROP_CHANNEL, "aeron:ipc")
+                .containsEntry(AeronRecord.PROP_POSITION, "4096")
+                .containsEntry(AeronRecord.PROP_INGEST_TS, "1754870400000");
+    }
+
+    @Test
+    public void testNoKeyByDefault() {
+        AeronRecord record = new AeronRecord(new byte[0], null, properties());
+
+        assertThat(record.getKey()).isEmpty();
+    }
+
+    @Test
+    public void testKeyIsExposedWhenSet() {
+        AeronRecord record = new AeronRecord(new byte[0], "42", properties());
+
+        assertThat(record.getKey()).contains("42");
+    }
+
+    @Test
+    public void testPropertiesAreImmutable() {
+        AeronRecord record = new AeronRecord(new byte[0], null, properties());
+
+        assertThatThrownBy(() -> record.getProperties().put("x", "y"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void testPropertiesAreCopiedFromCaller() {
+        // The polling thread reuses its own maps between fragments in some shapes of this
+        // code; the record must not alias whatever it was handed.
+        Map<String, String> mutable = properties();
+        AeronRecord record = new AeronRecord(new byte[0], null, mutable);
+
+        mutable.put(AeronRecord.PROP_SESSION_ID, "999");
+
+        assertThat(record.getProperties()).containsEntry(AeronRecord.PROP_SESSION_ID, "42");
+    }
+
+    @Test
+    public void testAckAndFailAreNoOps() {
+        // Plain Aeron has nothing to acknowledge. These must not throw, because the
+        // framework calls ack() on every successfully published record.
+        AeronRecord record = new AeronRecord(new byte[0], null, properties());
+
+        record.ack();
+        record.fail();
+    }
+}

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronSourceConfigTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronSourceConfigTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link AeronSourceConfig} deserialization and validation.
+ */
+public class AeronSourceConfigTest {
+
+    private static Map<String, Object> validMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("channel", "aeron:udp?endpoint=0.0.0.0:40123");
+        map.put("streamId", 1001);
+        return map;
+    }
+
+    @Test
+    public void testDefaults() throws Exception {
+        AeronSourceConfig config = AeronSourceConfig.load(validMap());
+
+        assertThat(config.getChannel()).isEqualTo("aeron:udp?endpoint=0.0.0.0:40123");
+        assertThat(config.getStreamId()).isEqualTo(1001);
+        assertThat(config.isUseEmbeddedMediaDriver()).isTrue();
+        assertThat(config.getAeronDirectoryName()).isNull();
+        assertThat(config.getIdleStrategy()).isEqualTo(IdleStrategies.BACKOFF);
+        assertThat(config.getFragmentLimit()).isEqualTo(256);
+        assertThat(config.isKeyBySessionId()).isFalse();
+        assertThat(config.getFragmentAssemblyBufferLength()).isZero();
+
+        config.validate();
+    }
+
+    @Test
+    public void testLoadAllFields() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("useEmbeddedMediaDriver", false);
+        map.put("aeronDirectoryName", "/tmp/aeron-test");
+        map.put("idleStrategy", "busyspin");
+        map.put("fragmentLimit", 64);
+        map.put("keyBySessionId", true);
+        map.put("fragmentAssemblyBufferLength", 8192);
+
+        AeronSourceConfig config = AeronSourceConfig.load(map);
+
+        assertThat(config.isUseEmbeddedMediaDriver()).isFalse();
+        assertThat(config.getAeronDirectoryName()).isEqualTo("/tmp/aeron-test");
+        assertThat(config.getIdleStrategy()).isEqualTo("busyspin");
+        assertThat(config.getFragmentLimit()).isEqualTo(64);
+        assertThat(config.isKeyBySessionId()).isTrue();
+        assertThat(config.getFragmentAssemblyBufferLength()).isEqualTo(8192);
+
+        config.validate();
+    }
+
+    @Test
+    public void testIpcChannelIsValid() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("channel", "aeron:ipc");
+
+        AeronSourceConfig config = AeronSourceConfig.load(map);
+        config.validate();
+
+        assertThat(config.getChannel()).isEqualTo("aeron:ipc");
+    }
+
+    @Test
+    public void testMissingChannelIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        map.remove("channel");
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("channel must be set");
+    }
+
+    @Test
+    public void testBlankChannelIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("channel", "   ");
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("channel must be set");
+    }
+
+    @Test
+    public void testMalformedChannelUriIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        // Aeron URIs must start with the "aeron:" scheme.
+        map.put("channel", "udp://0.0.0.0:40123");
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a valid Aeron URI");
+    }
+
+    @Test
+    public void testZeroStreamIdIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("streamId", 0);
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("streamId must not be 0");
+    }
+
+    @Test
+    public void testNegativeStreamIdIsAllowed() throws Exception {
+        Map<String, Object> map = validMap();
+        // Aeron stream ids are signed ints; only 0 is reserved.
+        map.put("streamId", -7);
+
+        AeronSourceConfig config = AeronSourceConfig.load(map);
+        config.validate();
+
+        assertThat(config.getStreamId()).isEqualTo(-7);
+    }
+
+    @Test
+    public void testUnknownIdleStrategyIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("idleStrategy", "spin-forever");
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("idleStrategy must be one of");
+    }
+
+    @Test
+    public void testNonPositiveFragmentLimitIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("fragmentLimit", 0);
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fragmentLimit must be positive");
+    }
+
+    @Test
+    public void testNegativeAssemblyBufferLengthIsRejected() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("fragmentAssemblyBufferLength", -1);
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fragmentAssemblyBufferLength must not be negative");
+    }
+
+    @Test
+    public void testExternalDriverRequiresDirectory() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("useEmbeddedMediaDriver", false);
+
+        assertThatThrownBy(() -> AeronSourceConfig.load(map).validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("aeronDirectoryName must be set");
+    }
+
+    @Test
+    public void testEmbeddedDriverDoesNotRequireDirectory() throws Exception {
+        Map<String, Object> map = validMap();
+        map.put("useEmbeddedMediaDriver", true);
+
+        AeronSourceConfig config = AeronSourceConfig.load(map);
+        config.validate();
+
+        assertThat(config.getAeronDirectoryName()).isNull();
+    }
+}

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronSourceContainerTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronSourceContainerTest.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import io.aeron.Aeron;
+import io.aeron.Publication;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.functions.api.Record;
+import org.awaitility.Awaitility;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Proves the full path: an Aeron publication, through {@link AeronSource}, into a real
+ * Pulsar broker running in a container, and back out through a consumer.
+ *
+ * <p>Only the broker is containerised. Aeron clients reach their media driver through
+ * memory-mapped files in a shared directory, so a driver inside a container cannot serve a
+ * client on the host; the Aeron leg therefore runs against a local driver over IPC. What the
+ * container adds over {@link AeronSourceIntegrationTest} is the assertion that payloads, keys
+ * and Aeron metadata survive a real publish and a real consume, rather than only reaching an
+ * in-memory list.
+ *
+ * <p>The drain loop here stands in for the function framework, which is what calls
+ * {@code read()} and publishes in production.
+ */
+public class AeronSourceContainerTest {
+
+    private static final String PULSAR_IMAGE =
+            System.getenv().getOrDefault("PULSAR_TEST_IMAGE", "apachepulsar/pulsar:4.1.3");
+
+    private static final String CHANNEL = "aeron:ipc";
+    private static final String PUBLICATION_CHANNEL = "aeron:ipc?term-length=1048576";
+    private static final int STREAM_ID = 1001;
+    private static final long TIMEOUT_SECONDS = 60L;
+    private static final int LARGER_THAN_MTU = 64 * 1024;
+
+    private PulsarContainer pulsarContainer;
+    private PulsarClient pulsarClient;
+    private PulsarAdmin admin;
+    private Producer<byte[]> producer;
+
+    private Path aeronDir;
+    private MediaDriver mediaDriver;
+    private Aeron publisherClient;
+    private Publication publication;
+
+    private AeronSource source;
+    private Thread drainThread;
+    private volatile Exception drainFailure;
+    private String topicName;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE))
+                .withStartupTimeout(Duration.ofMinutes(5));
+        pulsarContainer.start();
+
+        pulsarClient = PulsarClient.builder()
+                .serviceUrl(pulsarContainer.getPulsarBrokerUrl())
+                .build();
+        admin = PulsarAdmin.builder()
+                .serviceHttpUrl(pulsarContainer.getHttpServiceUrl())
+                .build();
+
+        // The broker creates the "public" tenant asynchronously during bootstrap and the
+        // container wait strategy can return before that lands.
+        Awaitility.await("public tenant created")
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(250, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .until(() -> admin.tenants().getTenants().contains("public"));
+
+        topicName = "persistent://public/default/aeron-in-" + System.nanoTime();
+        producer = pulsarClient.newProducer(Schema.BYTES).topic(topicName).create();
+
+        Path parent = Path.of(System.getProperty("aeron.test.dir",
+                System.getProperty("java.io.tmpdir")));
+        Files.createDirectories(parent);
+        aeronDir = Files.createTempDirectory(parent, "aeron-source-ct-");
+        mediaDriver = MediaDriver.launchEmbedded(new MediaDriver.Context()
+                .aeronDirectoryName(aeronDir.toString())
+                .threadingMode(ThreadingMode.SHARED)
+                .dirDeleteOnStart(true)
+                .dirDeleteOnShutdown(true));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (drainThread != null) {
+            drainThread.interrupt();
+            try {
+                drainThread.join(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            drainThread = null;
+        }
+        closeQuietly(publication);
+        closeQuietly(publisherClient);
+        closeQuietly(source);
+        source = null;
+        closeQuietly(mediaDriver);
+        closeQuietly(producer);
+        closeQuietly(pulsarClient);
+        closeQuietly(admin);
+        if (pulsarContainer != null) {
+            pulsarContainer.stop();
+            pulsarContainer = null;
+        }
+        deleteRecursively(aeronDir);
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            // Ignored during teardown so it cannot mask the test result.
+        }
+    }
+
+    private static void deleteRecursively(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (var walk = Files.walk(path)) {
+            walk.sorted((a, b) -> b.getNameCount() - a.getNameCount()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (Exception e) {
+                    // Best effort.
+                }
+            });
+        } catch (Exception e) {
+            // Best effort.
+        }
+    }
+
+    /**
+     * Starts the source and drains it into Pulsar, mirroring what the function framework
+     * does in production: read a record, publish it, then ack it.
+     */
+    private void startSourceAndDrain(Map<String, Object> config) throws Exception {
+        source = new AeronSource();
+        source.open(config, null);
+
+        drainThread = new Thread(() -> {
+            try {
+                while (!Thread.currentThread().isInterrupted()) {
+                    Record<byte[]> record = source.read();
+                    var message = producer.newMessage().value(record.getValue());
+                    record.getKey().ifPresent(message::key);
+                    record.getProperties().forEach(message::property);
+                    message.send();
+                    record.ack();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                // Surface a genuine publish failure instead of letting the test time out
+                // with a misleading "no messages arrived".
+                drainFailure = e;
+            }
+        }, "aeron-ct-drain");
+        drainThread.setDaemon(true);
+        drainThread.start();
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("channel", CHANNEL);
+        config.put("streamId", STREAM_ID);
+        // Attach to the driver the test owns, so the publisher and the source share it.
+        config.put("useEmbeddedMediaDriver", false);
+        config.put("aeronDirectoryName", mediaDriver.aeronDirectoryName());
+        config.put("idleStrategy", "sleeping");
+        return config;
+    }
+
+    private void connectPublisher() {
+        publisherClient = Aeron.connect(new Aeron.Context()
+                .aeronDirectoryName(mediaDriver.aeronDirectoryName()));
+        publication = publisherClient.addPublication(PUBLICATION_CHANNEL, STREAM_ID);
+        Awaitility.await("publication connected")
+                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .until(() -> publication.isConnected());
+    }
+
+    private void offer(byte[] payload) {
+        UnsafeBuffer buffer = new UnsafeBuffer(payload);
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (System.nanoTime() < deadlineNanos) {
+            long result = publication.offer(buffer, 0, payload.length);
+            if (result > 0) {
+                return;
+            }
+            if (result == Publication.CLOSED || result == Publication.MAX_POSITION_EXCEEDED) {
+                fail("Aeron publication is unusable, offer returned " + result);
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+        }
+        fail("Timed out offering a " + payload.length + " byte payload to Aeron");
+    }
+
+    private List<Message<byte[]>> consume(int expected) throws Exception {
+        List<Message<byte[]>> received = new ArrayList<>();
+        try (Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topic(topicName)
+                .subscriptionName("aeron-ct-" + System.nanoTime())
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe()) {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+            while (received.size() < expected && System.nanoTime() < deadline) {
+                if (drainFailure != null) {
+                    throw new AssertionError("Draining the source into Pulsar failed", drainFailure);
+                }
+                Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
+                if (message != null) {
+                    received.add(message);
+                    consumer.acknowledge(message);
+                }
+            }
+        }
+        return received;
+    }
+
+    @Test
+    public void testAeronMessagesReachAPulsarTopic() throws Exception {
+        startSourceAndDrain(baseConfig());
+        connectPublisher();
+
+        List<String> sent = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            String payload = "{\"seq\":" + i + ",\"symbol\":\"DEMO\"}";
+            sent.add(payload);
+            offer(payload.getBytes(StandardCharsets.UTF_8));
+        }
+
+        List<Message<byte[]>> received = consume(sent.size());
+
+        assertThat(received).hasSize(sent.size());
+        List<String> values = received.stream()
+                .map(m -> new String(m.getValue(), StandardCharsets.UTF_8))
+                .toList();
+        assertThat(values).containsExactlyElementsOf(sent);
+    }
+
+    @Test
+    public void testAeronMetadataSurvivesAsMessageProperties() throws Exception {
+        startSourceAndDrain(baseConfig());
+        connectPublisher();
+
+        offer("payload".getBytes(StandardCharsets.UTF_8));
+
+        List<Message<byte[]>> received = consume(1);
+
+        assertThat(received).hasSize(1);
+        Map<String, String> properties = received.get(0).getProperties();
+        assertThat(properties)
+                .containsEntry(AeronRecord.PROP_SESSION_ID, Integer.toString(publication.sessionId()))
+                .containsEntry(AeronRecord.PROP_STREAM_ID, Integer.toString(STREAM_ID))
+                .containsEntry(AeronRecord.PROP_CHANNEL, CHANNEL)
+                .containsKey(AeronRecord.PROP_POSITION)
+                .containsKey(AeronRecord.PROP_INGEST_TS);
+    }
+
+    @Test
+    public void testKeyBySessionIdReachesPulsarAsTheMessageKey() throws Exception {
+        Map<String, Object> config = baseConfig();
+        config.put("keyBySessionId", true);
+        startSourceAndDrain(config);
+        connectPublisher();
+
+        offer("keyed".getBytes(StandardCharsets.UTF_8));
+
+        List<Message<byte[]>> received = consume(1);
+
+        assertThat(received).hasSize(1);
+        assertThat(received.get(0).getKey()).isEqualTo(Integer.toString(publication.sessionId()));
+    }
+
+    @Test
+    public void testFragmentedMessageArrivesWholeInPulsar() throws Exception {
+        startSourceAndDrain(baseConfig());
+        connectPublisher();
+
+        String large = RandomStringUtils.insecure().nextAlphanumeric(LARGER_THAN_MTU);
+        offer(large.getBytes(StandardCharsets.UTF_8));
+
+        List<Message<byte[]>> received = consume(1);
+
+        assertThat(received).hasSize(1);
+        assertThat(received.get(0).getValue()).hasSize(LARGER_THAN_MTU);
+        assertThat(new String(received.get(0).getValue(), StandardCharsets.UTF_8)).isEqualTo(large);
+    }
+}

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronSourceIntegrationTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/AeronSourceIntegrationTest.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import io.aeron.Aeron;
+import io.aeron.Publication;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end tests for {@link AeronSource} over real Aeron IPC.
+ *
+ * <p>Everything runs in one JVM against an embedded media driver. This is not a shortcut
+ * around Testcontainers: an Aeron client reaches its media driver through memory-mapped
+ * files in a shared directory, so a driver inside a container is unreachable from a test on
+ * the host. The container-based coverage lives in {@link AeronSourceContainerTest}, which
+ * uses a container for the Pulsar broker — the one leg that can be containerised.
+ *
+ * <p>IPC still exercises the code paths that matter here: fragmentation and reassembly,
+ * header metadata, and the copy out of the term buffer.
+ */
+public class AeronSourceIntegrationTest {
+
+    private static final String CHANNEL = "aeron:ipc";
+    /** Publications set a small term length so the test's mapped files stay modest in CI. */
+    private static final String PUBLICATION_CHANNEL = "aeron:ipc?term-length=1048576";
+    private static final int STREAM_ID = 1001;
+    private static final long TIMEOUT_SECONDS = 30L;
+    /** The IPC MTU defaults to 1408 bytes, so anything above that fragments. */
+    private static final int LARGER_THAN_MTU = 64 * 1024;
+
+    private Path aeronDir;
+    private AeronSource source;
+    private Aeron publisherClient;
+    private Publication publication;
+    private Thread readerThread;
+    private List<Record<byte[]>> collected;
+    private SourceContext sourceContext;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        sourceContext = mock(SourceContext.class);
+        // Not /dev/shm: it is routinely too small in CI containers for Aeron's buffers.
+        Path parent = Path.of(System.getProperty("aeron.test.dir",
+                System.getProperty("java.io.tmpdir")));
+        Files.createDirectories(parent);
+        aeronDir = Files.createTempDirectory(parent, "aeron-source-it-");
+        collected = new CopyOnWriteArrayList<>();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (readerThread != null) {
+            readerThread.interrupt();
+            try {
+                readerThread.join(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            readerThread = null;
+        }
+        closeQuietly(publication);
+        publication = null;
+        closeQuietly(publisherClient);
+        publisherClient = null;
+        if (source != null) {
+            try {
+                source.close();
+            } catch (Exception e) {
+                // Do not let a teardown failure mask the test result.
+            }
+            source = null;
+        }
+        deleteRecursively(aeronDir);
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                // Ignored during teardown.
+            }
+        }
+    }
+
+    private static void deleteRecursively(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (var walk = Files.walk(path)) {
+            walk.sorted((a, b) -> b.getNameCount() - a.getNameCount()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (Exception e) {
+                    // Best effort; the driver may still hold a mapping.
+                }
+            });
+        } catch (Exception e) {
+            // Best effort.
+        }
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("channel", CHANNEL);
+        config.put("streamId", STREAM_ID);
+        config.put("useEmbeddedMediaDriver", true);
+        // Pinning the directory lets the test's publisher attach to the source's own driver.
+        config.put("aeronDirectoryName", aeronDir.toString());
+        config.put("idleStrategy", "sleeping");
+        return config;
+    }
+
+    /** Starts the source and a background thread that drains it, as the framework would. */
+    private void startSource(Map<String, Object> config) throws Exception {
+        source = new AeronSource();
+        source.open(config, sourceContext);
+
+        readerThread = new Thread(() -> {
+            try {
+                while (!Thread.currentThread().isInterrupted()) {
+                    collected.add(source.read());
+                }
+            } catch (Exception e) {
+                // Interrupted at teardown.
+            }
+        }, "aeron-it-reader");
+        readerThread.setDaemon(true);
+        readerThread.start();
+    }
+
+    private void connectPublisher() {
+        publisherClient = Aeron.connect(new Aeron.Context().aeronDirectoryName(aeronDir.toString()));
+        publication = publisherClient.addPublication(PUBLICATION_CHANNEL, STREAM_ID);
+        Awaitility.await("publication connected to the source's subscription")
+                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .until(() -> publication.isConnected());
+    }
+
+    /** Offers a payload, retrying while Aeron reports transient backpressure. */
+    private void offer(byte[] payload) {
+        UnsafeBuffer buffer = new UnsafeBuffer(payload);
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (System.nanoTime() < deadlineNanos) {
+            long result = publication.offer(buffer, 0, payload.length);
+            if (result > 0) {
+                return;
+            }
+            if (result == Publication.CLOSED || result == Publication.MAX_POSITION_EXCEEDED) {
+                fail("Aeron publication is unusable, offer returned " + result);
+            }
+            // BACK_PRESSURED, NOT_CONNECTED and ADMIN_ACTION are all transient.
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+        }
+        fail("Timed out offering a " + payload.length + " byte payload to Aeron");
+    }
+
+    private void awaitRecords(int count) {
+        Awaitility.await("source emitted " + count + " records")
+                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .until(() -> collected.size() >= count);
+    }
+
+    private static List<String> valuesAsStrings(List<Record<byte[]>> records) {
+        return records.stream()
+                .map(r -> new String(r.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testMessagesFlowFromAeronToTheSource() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+
+        List<String> sent = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            String payload = "{\"seq\":" + i + ",\"symbol\":\"DEMO\"}";
+            sent.add(payload);
+            offer(payload.getBytes(StandardCharsets.UTF_8));
+        }
+
+        awaitRecords(sent.size());
+
+        // A single publication is a single Aeron session, so ordering is guaranteed here.
+        // That is a property of this setup, not of Aeron across sessions.
+        assertThat(valuesAsStrings(collected)).containsExactlyElementsOf(sent);
+    }
+
+    @Test
+    public void testMessageLargerThanMtuIsReassembled() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+
+        // Random content so a truncated or mis-stitched reassembly cannot accidentally match.
+        String large = RandomStringUtils.insecure().nextAlphanumeric(LARGER_THAN_MTU);
+        offer(large.getBytes(StandardCharsets.UTF_8));
+
+        awaitRecords(1);
+
+        assertThat(collected).hasSize(1);
+        assertThat(collected.get(0).getValue()).hasSize(LARGER_THAN_MTU);
+        assertThat(new String(collected.get(0).getValue(), StandardCharsets.UTF_8)).isEqualTo(large);
+    }
+
+    @Test
+    public void testMixedSizesInterleaveCorrectly() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+
+        // Interleaving fragmented and unfragmented messages catches assembler state that
+        // leaks between messages.
+        List<String> sent = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            String small = "small-" + i;
+            sent.add(small);
+            offer(small.getBytes(StandardCharsets.UTF_8));
+
+            String large = "large-" + i + "-"
+                    + RandomStringUtils.insecure().nextAlphanumeric(LARGER_THAN_MTU);
+            sent.add(large);
+            offer(large.getBytes(StandardCharsets.UTF_8));
+        }
+
+        awaitRecords(sent.size());
+
+        assertThat(valuesAsStrings(collected)).containsExactlyElementsOf(sent);
+    }
+
+    @Test
+    public void testRecordMetadataMatchesThePublication() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+
+        offer("payload".getBytes(StandardCharsets.UTF_8));
+        awaitRecords(1);
+
+        Record<byte[]> record = collected.get(0);
+        assertThat(record.getProperties())
+                .containsEntry(AeronRecord.PROP_SESSION_ID, Integer.toString(publication.sessionId()))
+                .containsEntry(AeronRecord.PROP_STREAM_ID, Integer.toString(STREAM_ID))
+                .containsEntry(AeronRecord.PROP_CHANNEL, CHANNEL);
+        assertThat(Long.parseLong(record.getProperties().get(AeronRecord.PROP_POSITION))).isPositive();
+        assertThat(Long.parseLong(record.getProperties().get(AeronRecord.PROP_INGEST_TS))).isPositive();
+        // Default config: no key.
+        assertThat(record.getKey()).isEmpty();
+    }
+
+    @Test
+    public void testKeyBySessionIdUsesTheAeronSession() throws Exception {
+        Map<String, Object> config = baseConfig();
+        config.put("keyBySessionId", true);
+        startSource(config);
+        connectPublisher();
+
+        offer("payload".getBytes(StandardCharsets.UTF_8));
+        awaitRecords(1);
+
+        assertThat(collected.get(0).getKey()).contains(Integer.toString(publication.sessionId()));
+    }
+
+    @Test
+    public void testPositionAdvancesAcrossMessages() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+
+        for (int i = 0; i < 10; i++) {
+            offer(("msg-" + i).getBytes(StandardCharsets.UTF_8));
+        }
+        awaitRecords(10);
+
+        List<Long> positions = collected.stream()
+                .map(r -> Long.parseLong(r.getProperties().get(AeronRecord.PROP_POSITION)))
+                .collect(Collectors.toList());
+
+        assertThat(positions).isSorted();
+        assertThat(positions.get(positions.size() - 1)).isGreaterThan(positions.get(0));
+    }
+
+    @Test
+    public void testFragmentAndRecordMetricsAreBothReported() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+
+        // One fragmented message: the record counter must see one message while the fragment
+        // counter, driven by poll(), sees the wire-level fragments it was split into.
+        offer(RandomStringUtils.insecure().nextAlphanumeric(LARGER_THAN_MTU)
+                .getBytes(StandardCharsets.UTF_8));
+        awaitRecords(1);
+
+        verify(sourceContext, atLeastOnce())
+                .recordMetric(eq(AeronPollingRunner.METRIC_FRAGMENTS_RECEIVED), anyDouble());
+        verify(sourceContext).recordMetric(eq(AeronPollingRunner.METRIC_RECORDS_CONSUMED), eq(1.0d));
+    }
+
+    @Test
+    public void testCloseStopsTheSourceCleanly() throws Exception {
+        startSource(baseConfig());
+        connectPublisher();
+        offer("before-close".getBytes(StandardCharsets.UTF_8));
+        awaitRecords(1);
+
+        source.close();
+        AeronSource closed = source;
+        source = null;
+
+        // close() must be safe to call twice; the framework can invoke it on an already
+        // stopped instance.
+        closed.close();
+    }
+
+    @Test
+    public void testOpenWithInvalidConfigFailsFastAndLeavesNothingRunning() {
+        Map<String, Object> config = baseConfig();
+        config.put("channel", "not-an-aeron-uri");
+
+        AeronSource bad = new AeronSource();
+        try {
+            bad.open(config, null);
+            fail("Expected open() to reject the malformed channel URI");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+            assertThat(e).hasMessageContaining("not a valid Aeron URI");
+        }
+        // A failed open() must not leave a media driver behind; the framework will not call
+        // close() for it.
+        assertThat(aeronDir.resolve("cnc.dat")).doesNotExist();
+    }
+
+    @Test
+    public void testExternalMediaDriverModeAttachesToAnExistingDriver() throws Exception {
+        // Covers the useEmbeddedMediaDriver=false path: the source must attach to a driver it
+        // did not start, and must not delete that driver's directory on close.
+        io.aeron.driver.MediaDriver driver = io.aeron.driver.MediaDriver.launchEmbedded(
+                new io.aeron.driver.MediaDriver.Context()
+                        .aeronDirectoryName(aeronDir.toString())
+                        .threadingMode(io.aeron.driver.ThreadingMode.SHARED)
+                        .dirDeleteOnStart(true)
+                        .dirDeleteOnShutdown(true));
+        try {
+            Map<String, Object> config = baseConfig();
+            config.put("useEmbeddedMediaDriver", false);
+            config.put("aeronDirectoryName", driver.aeronDirectoryName());
+            startSource(config);
+            connectPublisher();
+
+            offer("external-driver".getBytes(StandardCharsets.UTF_8));
+            awaitRecords(1);
+
+            assertThat(valuesAsStrings(collected)).containsExactly("external-driver");
+
+            source.close();
+            source = null;
+            // The externally owned driver is still usable after the source closed.
+            assertThat(driver.aeronDirectoryName()).isNotNull();
+        } finally {
+            driver.close();
+        }
+    }
+}

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/IdleStrategiesTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/IdleStrategiesTest.java
@@ -86,6 +86,16 @@ public class IdleStrategiesTest {
     }
 
     @Test
+    public void testSupportedStrategiesIsImmutable() {
+        // The list is handed straight out, so a caller mutating it would silently change what
+        // isSupported() and create() accept.
+        assertThatThrownBy(() -> IdleStrategies.supportedStrategies().set(0, "nonsense"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> IdleStrategies.supportedStrategies().add("nonsense"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
     public void testSupportedStrategiesListsAllFour() {
         assertThat(IdleStrategies.supportedStrategies())
                 .containsExactlyInAnyOrder(IdleStrategies.BACKOFF, IdleStrategies.SLEEPING,

--- a/aeron/src/test/java/org/apache/pulsar/io/aeron/IdleStrategiesTest.java
+++ b/aeron/src/test/java/org/apache/pulsar/io/aeron/IdleStrategiesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.aeron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.agrona.concurrent.BackoffIdleStrategy;
+import org.agrona.concurrent.BusySpinIdleStrategy;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.SleepingMillisIdleStrategy;
+import org.agrona.concurrent.YieldingIdleStrategy;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the {@code idleStrategy} config value to Agrona {@link IdleStrategy} mapping.
+ */
+public class IdleStrategiesTest {
+
+    @DataProvider(name = "strategies")
+    public static Object[][] strategies() {
+        return new Object[][]{
+                {IdleStrategies.BACKOFF, BackoffIdleStrategy.class},
+                {IdleStrategies.SLEEPING, SleepingMillisIdleStrategy.class},
+                {IdleStrategies.YIELDING, YieldingIdleStrategy.class},
+                {IdleStrategies.BUSYSPIN, BusySpinIdleStrategy.class},
+        };
+    }
+
+    @Test(dataProvider = "strategies")
+    public void testCreateMapsNameToStrategy(String name, Class<?> expected) {
+        assertThat(IdleStrategies.create(name)).isInstanceOf(expected);
+    }
+
+    @Test(dataProvider = "strategies")
+    public void testNamesAreCaseAndWhitespaceInsensitive(String name, Class<?> expected) {
+        assertThat(IdleStrategies.create("  " + name.toUpperCase(java.util.Locale.ROOT) + " "))
+                .isInstanceOf(expected);
+    }
+
+    @Test
+    public void testEachCallReturnsAFreshInstance() {
+        // Idle strategies carry mutable spin/yield state, so two polling threads must never
+        // be handed the same object.
+        IdleStrategy first = IdleStrategies.create(IdleStrategies.BACKOFF);
+        IdleStrategy second = IdleStrategies.create(IdleStrategies.BACKOFF);
+
+        assertThat(first).isNotSameAs(second);
+    }
+
+    @Test
+    public void testUnknownNameIsRejected() {
+        assertThatThrownBy(() -> IdleStrategies.create("spin-forever"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown idleStrategy 'spin-forever'");
+    }
+
+    @Test
+    public void testNullNameIsRejected() {
+        assertThatThrownBy(() -> IdleStrategies.create(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testIsSupported() {
+        assertThat(IdleStrategies.isSupported(IdleStrategies.BACKOFF)).isTrue();
+        assertThat(IdleStrategies.isSupported("BUSYSPIN")).isTrue();
+        assertThat(IdleStrategies.isSupported("spin-forever")).isFalse();
+        assertThat(IdleStrategies.isSupported(null)).isFalse();
+    }
+
+    @Test
+    public void testSupportedStrategiesListsAllFour() {
+        assertThat(IdleStrategies.supportedStrategies())
+                .containsExactlyInAnyOrder(IdleStrategies.BACKOFF, IdleStrategies.SLEEPING,
+                        IdleStrategies.YIELDING, IdleStrategies.BUSYSPIN);
+    }
+}

--- a/distribution/io/build.gradle.kts
+++ b/distribution/io/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     connectorNars(project(":file"))
     connectorNars(project(":canal"))
     connectorNars(project(":netty"))
+    connectorNars(project(":aeron"))
     connectorNars(project(":mongo"))
     connectorNars(project(":debezium:pulsar-io-debezium-mariadb"))
     connectorNars(project(":debezium:pulsar-io-debezium-mysql"))

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(project(":kinesis"))
     implementation(project(":mongo"))
     implementation(project(":netty"))
+    implementation(project(":aeron"))
     implementation(project(":nsq"))
     implementation(project(":rabbitmq"))
     implementation(project(":redis"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ bookkeeper = "4.17.3"
 zookeeper = "3.9.5"
 netty = "4.1.132.Final"
 netty-iouring = "0.0.26.Final"
+aeron = "1.48.0"
 jetty = "12.1.8"
 jetty9 = "9.4.58.v20250814"
 jersey = "2.42"
@@ -221,6 +222,13 @@ netty-codec-http = { module = "io.netty:netty-codec-http" }
 netty-incubator-transport-classes-io_uring = { module = "io.netty.incubator:netty-incubator-transport-classes-io_uring", version.ref = "netty-iouring" }
 netty-incubator-transport-native-io-uring = { module = "io.netty.incubator:netty-incubator-transport-native-io_uring", version.ref = "netty-iouring" }
 netty-reactive-streams = { module = "com.typesafe.netty:netty-reactive-streams", version.ref = "netty-reactive-streams" }
+
+# Aeron. aeron-driver is needed for the embedded media driver; it depends on
+# aeron-client, which brings agrona transitively. The aeron-all uber-jar is
+# deliberately not used: it duplicates agrona and pulls in archive/cluster code
+# the source connector does not need.
+aeron-client = { module = "io.aeron:aeron-client", version.ref = "aeron" }
+aeron-driver = { module = "io.aeron:aeron-driver", version.ref = "aeron" }
 # Protobuf / gRPC
 protobuf-bom = { module = "com.google.protobuf:protobuf-bom", version.ref = "protobuf" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,6 +62,7 @@ require(providers.gradleProperty("skipJavaVersionCheck").isPresent
 include("pulsar-connectors-dependencies")
 
 // Simple connectors (flat layout, top-level directories)
+include("aeron")
 include("aerospike")
 include("alluxio")
 include("aws")


### PR DESCRIPTION
Fixes #127

### Motivation

[Aeron](https://github.com/aeron-io/aeron) is a brokerless, low-latency message transport widely
used in finance and other latency-sensitive domains. It is a transport, not a broker: no
persistence, no consumer groups, no resumable offsets — data lives in the publisher's term
buffers until they rotate.

Users running Aeron today have no supported way to land that traffic in Pulsar for durable
storage, fan-out, or replication; the only option is a hand-rolled bridge application. This adds
a first-class source connector so Aeron can stay on the hot path while Pulsar becomes the durable
distribution layer, with no change to existing Aeron publishers.

### Modifications

New `aeron` module, following `netty` as the closest structural analogue (both are push-based
network sources).

- `AeronSource` — `PushSource<byte[]>`. Aeron only delivers to a caller that polls, so the
  pull-style `Source.read()` contract does not fit: a dedicated thread runs the poll loop and
  pushes into the source's queue. `consume()` blocking when that queue fills is the backpressure
  mechanism, which in turn pushes back on unicast publishers via Aeron flow control.
- `AeronPollingRunner` — the poll loop. **The payload is copied out of the term buffer inside the
  fragment handler.** Aeron reuses term buffers as soon as the callback returns, so without the
  copy records would mutate under the consumer and corrupt intermittently under load rather than
  fail cleanly. This is the one thing in the connector most likely to be broken by a well-meaning
  refactor, so it carries an explicit comment and a dedicated test.
- `AeronRecord` — carries `aeron.session-id`, `aeron.stream-id`, `aeron.channel`, `aeron.position`
  and `aeron.ingest-ts`. `keyBySessionId` optionally sets the record key from the Aeron session,
  which lets key_shared subscriptions and topic compaction group by session. `ack()`/`fail()` are
  no-ops — plain Aeron has nothing to acknowledge and cannot redeliver.
- `AeronPoller` — small interface the poll loop sits behind, so an Aeron Archive backed
  implementation can be added later without reworking the source lifecycle.
- `AeronSourceConfig` / `IdleStrategies` — config with fail-fast validation (channel URI parses,
  non-zero stream id, known idle strategy) and the idle-strategy mapping.

Module wired into `settings.gradle.kts`, `distribution/io` and `docs`.

Two metrics make behaviour observable: `aeron-fragments-received` is recorded in the poll loop
from `subscription.poll()` (wire-level fragments) and `aeron-records-consumed` in the handler
(whole messages). They are deliberately not both recorded in the handler — `FragmentAssembler`
invokes it once per reassembled message, so doing that would under-report exactly the fragmented
traffic the metric exists to expose.

**Delivery semantics: at-most-once.** This is a property of plain Aeron, not an implementation
shortcut, and is documented on `AeronSource` and `AeronRecord`. Loss windows are connector
restart (no resumable position exists), and a multicast subscriber falling behind past term
rotation. Lossless ingestion requires Aeron Archive, which is out of scope here.

Dependencies: `io.aeron:aeron-client` + `aeron-driver` (Apache-2.0, ASF category A) rather than
the `aeron-all` uber-jar — smaller NAR, no duplicate agrona classes. agrona arrives transitively.
Aeron is not provided by the function runtime, so it is bundled in the NAR.

### Verifying this change

57 tests, all passing locally.

- Unit: config validation, idle-strategy mapping, record metadata, and the buffer-copy semantics
  (the test overwrites the frame after the handler returns and asserts the emitted payload is
  unaffected). `Header` is final and reads its fields straight out of the buffer it is attached
  to, so these build a real Aeron data frame rather than mocking it.
- `AeronSourceIntegrationTest` — real Aeron over `aeron:ipc` with an embedded media driver:
  larger-than-MTU reassembly, interleaved small/large messages (which catches assembler state
  leaking between messages), header metadata, position monotonicity, both media-driver modes, and
  fail-fast on a malformed channel URI.
- `AeronSourceContainerTest` — Testcontainers `PulsarContainer`, driving Aeron through the source
  into a real broker and back out through a consumer, asserting payloads, message key and
  `aeron.*` properties survive the round trip.

On why Testcontainers covers only the broker leg: an Aeron client reaches its media driver
through memory-mapped files in a shared directory, so a driver inside a container is unreachable
from a test on the host. The Aeron leg therefore runs against a local driver over IPC. Both test
classes pin the driver directory under the build dir rather than `/dev/shm`, which is routinely
too small in CI containers.

Separately, the connector has been exercised end-to-end outside the test suite over Aeron **UDP**
between two containers — 1000/1000 messages delivered, including with payloads padded past the
1408-byte MTU so every message fragmented on the wire.

### Does this pull request potentially affect one of the following parts?

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The wire protocol
- [ ] The rest endpoints
- [ ] The admin cli options
- [ ] Anything that affects deployment

This adds a new, self-contained connector module. It changes no existing module's behaviour; the
only edits outside `aeron/` are the three registration points and the new version-catalog entries.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`

Config is documented via `@FieldDoc` on `AeronSourceConfig`, which is what the `docs` module
generates from. Delivery semantics and the parallelism assumption are documented in class javadoc.
