### PR TITLE
[feat][io] Cassandra sink: support authenticated clusters

### DIFF
--- a/cassandra/build.gradle.kts
+++ b/cassandra/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 }
 dependencies {
     implementation(libs.pulsar.io.core)
+    implementation(libs.pulsar.io.common)
     implementation(libs.jackson.databind)
     implementation(libs.jackson.dataformat.yaml)
     implementation(libs.cassandra.driver)

--- a/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
+++ b/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
@@ -59,6 +59,7 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
                 || cassandraSinkConfig.getColumnName() == null) {
             throw new IllegalArgumentException("Required property not set.");
         }
+        cassandraSinkConfig.validateCredentials();
         createClient(cassandraSinkConfig.getRoots());
         statement = session.prepare("INSERT INTO " + cassandraSinkConfig.getColumnFamily() + " ("
                 + cassandraSinkConfig.getKeyname() + ", " + cassandraSinkConfig.getColumnName() + ") VALUES (?, ?)");
@@ -104,8 +105,7 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
         }
         // Authenticate only when credentials were supplied; an unset pair leaves the connection
         // exactly as it was before these settings existed.
-        if (hasText(cassandraSinkConfig.getUserName())
-                && hasText(cassandraSinkConfig.getPassword())) {
+        if (cassandraSinkConfig.hasCredentials()) {
             b.withCredentials(cassandraSinkConfig.getUserName(), cassandraSinkConfig.getPassword());
         }
         cluster = b.withoutJMXReporting().build();
@@ -114,8 +114,4 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
     }
 
     public abstract KeyValue<K, V> extractKeyValue(Record<byte[]> record);
-
-    private static boolean hasText(String value) {
-        return value != null && !value.trim().isEmpty();
-    }
 }

--- a/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
+++ b/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Map;
 import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.common.IOConfigUtils;
 import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
@@ -47,7 +48,10 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        cassandraSinkConfig = CassandraSinkConfig.load(config);
+        // loadWithSecrets rather than load(): it resolves @FieldDoc(sensitive = true) fields from the
+        // connector's secrets provider, so the password need not sit in plaintext config. Fields with
+        // no secret configured still come from the config map, as before.
+        cassandraSinkConfig = IOConfigUtils.loadWithSecrets(config, CassandraSinkConfig.class, sinkContext);
         if (cassandraSinkConfig.getRoots() == null
                 || cassandraSinkConfig.getKeyspace() == null
                 || cassandraSinkConfig.getKeyname() == null
@@ -98,10 +102,20 @@ public abstract class CassandraAbstractSink<K, V> implements Sink<byte[]> {
                 b.withPort(Integer.parseInt(hostPort[1]));
             }
         }
+        // Authenticate only when credentials were supplied; an unset pair leaves the connection
+        // exactly as it was before these settings existed.
+        if (hasText(cassandraSinkConfig.getUserName())
+                && hasText(cassandraSinkConfig.getPassword())) {
+            b.withCredentials(cassandraSinkConfig.getUserName(), cassandraSinkConfig.getPassword());
+        }
         cluster = b.withoutJMXReporting().build();
         session = cluster.connect();
         session.execute("USE " + cassandraSinkConfig.getKeyspace());
     }
 
     public abstract KeyValue<K, V> extractKeyValue(Record<byte[]> record);
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
 }

--- a/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraSinkConfig.java
+++ b/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraSinkConfig.java
@@ -39,14 +39,16 @@ public class CassandraSinkConfig implements Serializable {
         defaultValue = "",
         sensitive = true,
         help = "Username used to authenticate against the cluster specified by `roots`. "
-                + "Leave unset for a cluster that does not require authentication.")
+                + "Must be set together with the other half of the pair; leave both unset "
+                + "for a cluster that does not require authentication.")
     private String userName;
     @FieldDoc(
         required = false,
         defaultValue = "",
         sensitive = true,
         help = "Password used to authenticate against the cluster specified by `roots`. "
-                + "Leave unset for a cluster that does not require authentication.")
+                + "Must be set together with the other half of the pair; leave both unset "
+                + "for a cluster that does not require authentication.")
     private String password;
     @FieldDoc(
         required = true,
@@ -82,5 +84,32 @@ public class CassandraSinkConfig implements Serializable {
     public static CassandraSinkConfig load(Map<String, Object> map) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(mapper.writeValueAsString(map), CassandraSinkConfig.class);
+    }
+
+    /**
+     * Rejects a credential pair with only one half set. Half a pair is never a meaningful
+     * configuration — whichever half is present, the intent was to authenticate — and connecting
+     * unauthenticated instead turns a typo into either a rejection from the server that names
+     * neither setting, or a silent success against a cluster that does not yet require
+     * authentication. Sinks call this before connecting, so the failure names what is wrong.
+     */
+    public void validateCredentials() {
+        if (hasText(userName) != hasText(password)) {
+            throw new IllegalArgumentException("userName and password must be supplied together: "
+                    + "set both to authenticate, or neither to connect to a cluster that does not "
+                    + "require authentication.");
+        }
+    }
+
+    /**
+     * Whether to authenticate at all. Only ever true for a complete pair, and
+     * {@link #validateCredentials()} has already rejected an incomplete one.
+     */
+    public boolean hasCredentials() {
+        return hasText(userName) && hasText(password);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraSinkConfig.java
+++ b/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraSinkConfig.java
@@ -35,6 +35,20 @@ public class CassandraSinkConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @FieldDoc(
+        required = false,
+        defaultValue = "",
+        sensitive = true,
+        help = "Username used to authenticate against the cluster specified by `roots`. "
+                + "Leave unset for a cluster that does not require authentication.")
+    private String userName;
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        sensitive = true,
+        help = "Password used to authenticate against the cluster specified by `roots`. "
+                + "Leave unset for a cluster that does not require authentication.")
+    private String password;
+    @FieldDoc(
         required = true,
         defaultValue = "",
         help = "A comma-separated list of cassandra hosts to connect to")

--- a/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthEnforcementTest.java
+++ b/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthEnforcementTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.cassandra;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.AuthenticationException;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SinkContext;
+import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Drives {@link CassandraStringSink} against a Cassandra that actually enforces authentication, and
+ * so asserts what {@link CassandraSinkAuthTest} cannot: that a connection without credentials — or
+ * with the wrong ones — is refused by the server, and that the credentials the sink is configured
+ * with are what gets it past that refusal.
+ *
+ * <p>The container runs {@code PasswordAuthenticator} instead of the image default
+ * {@code AllowAllAuthenticator}. It gets there by editing the shipped {@code cassandra.yaml} in
+ * place rather than by mounting a replacement: {@code withConfigurationOverride()} maps a whole
+ * directory over {@code /etc/cassandra}, which would mean carrying a complete, version-matched copy
+ * of every file Cassandra reads from there, while a one-line {@code sed} touches only the setting
+ * under test. The {@code grep} that follows it makes a no-op substitution fatal — if a future image
+ * tag expresses the authenticator differently, the container fails to start rather than quietly
+ * reverting to {@code AllowAllAuthenticator} and leaving every assertion here vacuous.
+ * {@link #serverRejectsUnauthenticatedConnection()} is the second half of that guard: it fails the
+ * suite if the server ever stops enforcing, whatever the reason.
+ */
+public class CassandraSinkAuthEnforcementTest {
+
+    private static final String IMAGE = "cassandra:4.1";
+    private static final String CONF = "/etc/cassandra/cassandra.yaml";
+    private static final String SUPERUSER = "cassandra";
+    private static final String SUPERUSER_PASSWORD = "cassandra";
+
+    private static final String ENABLE_PASSWORD_AUTHENTICATION =
+            "sed -i 's/^authenticator:.*/authenticator: PasswordAuthenticator/' " + CONF
+                    + " && grep -q '^authenticator: PasswordAuthenticator' " + CONF
+                    + " && exec docker-entrypoint.sh cassandra -f";
+
+    private static final String KEYSPACE = "auth_enforced_ks";
+    private static final String TABLE = "auth_enforced_table";
+    private static final String KEY_COLUMN = "key";
+    private static final String VALUE_COLUMN = "value";
+
+    private CassandraContainer<?> cassandraContainer;
+
+    @BeforeClass
+    public void setUp() {
+        cassandraContainer = new CassandraContainer<>(IMAGE)
+                .withCommand("sh", "-c", ENABLE_PASSWORD_AUTHENTICATION)
+                // The default superuser role is created on a delay after the ring is joined, which is
+                // later than the CQL port opening; waiting for the port alone would let a test connect
+                // before there is anything to authenticate against.
+                .waitingFor(new WaitAllStrategy()
+                        .withStrategy(Wait.forListeningPort())
+                        .withStrategy(new LogMessageWaitStrategy()
+                                .withRegEx(".*Created default superuser role.*\\n"))
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        cassandraContainer.start();
+
+        try (Cluster cluster = authenticatedCluster();
+             Session session = cluster.connect()) {
+            session.execute("CREATE KEYSPACE " + KEYSPACE
+                    + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':'1'}");
+            session.execute("CREATE TABLE " + KEYSPACE + "." + TABLE
+                    + " (" + KEY_COLUMN + " text PRIMARY KEY, " + VALUE_COLUMN + " text)");
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown() {
+        if (cassandraContainer != null) {
+            cassandraContainer.stop();
+            cassandraContainer = null;
+        }
+    }
+
+    /**
+     * Establishes that the server under test enforces authentication at all, using the driver
+     * directly so that nothing about the sink is involved. Every other assertion in this class is
+     * only worth something while this one holds.
+     */
+    @Test
+    public void serverRejectsUnauthenticatedConnection() {
+        try (Cluster cluster = cassandraContainer.getCluster()) {
+            cluster.connect();
+            fail("Expected the server to reject a connection carrying no credentials");
+        } catch (Exception e) {
+            assertNotNull(authenticationFailure(e), "Not an authentication failure: " + e);
+        }
+    }
+
+    @Test
+    public void sinkFailsToOpenWithoutCredentials() {
+        assertOpenIsRejected(baseConfig());
+    }
+
+    @Test
+    public void sinkFailsToOpenWithWrongPassword() {
+        Map<String, Object> config = baseConfig();
+        config.put("userName", SUPERUSER);
+        config.put("password", "not-the-password");
+
+        assertOpenIsRejected(config);
+    }
+
+    @Test
+    public void sinkWritesWhenCredentialsAreCorrect() throws Exception {
+        Map<String, Object> config = baseConfig();
+        config.put("userName", SUPERUSER);
+        config.put("password", SUPERUSER_PASSWORD);
+
+        String key = "authenticated";
+        CassandraStringSink sink = new CassandraStringSink();
+        try {
+            sink.open(config, mock(SinkContext.class));
+
+            CompletableFuture<Void> acked = new CompletableFuture<>();
+            sink.write(new Record<byte[]>() {
+                @Override
+                public Optional<String> getKey() {
+                    return Optional.of(key);
+                }
+
+                @Override
+                public byte[] getValue() {
+                    return ("value-" + key).getBytes();
+                }
+
+                @Override
+                public void ack() {
+                    acked.complete(null);
+                }
+
+                @Override
+                public void fail() {
+                    acked.completeExceptionally(new RuntimeException("Record failed"));
+                }
+            });
+            acked.get();
+        } finally {
+            sink.close();
+        }
+
+        try (Cluster cluster = authenticatedCluster();
+             Session session = cluster.connect(KEYSPACE)) {
+            assertEquals(session
+                    .execute("SELECT * FROM " + TABLE + " WHERE " + KEY_COLUMN + " = '" + key + "'")
+                    .one()
+                    .getString(VALUE_COLUMN), "value-" + key);
+        }
+    }
+
+    private void assertOpenIsRejected(Map<String, Object> config) {
+        CassandraStringSink sink = new CassandraStringSink();
+        try {
+            sink.open(config, mock(SinkContext.class));
+            fail("Expected open() to be rejected by the server");
+        } catch (Exception e) {
+            assertNotNull(authenticationFailure(e), "Not an authentication failure: " + e);
+        }
+    }
+
+    /**
+     * Finds the {@link AuthenticationException} the driver raised, or {@code null} if the failure was
+     * something else. The driver reports an unusable contact point either directly or wrapped in a
+     * {@link NoHostAvailableException} holding the per-host cause, so both shapes are unwrapped here
+     * rather than asserting on one and hoping.
+     */
+    private static AuthenticationException authenticationFailure(Throwable t) {
+        for (Throwable current = t; current != null; current = current.getCause()) {
+            if (current instanceof AuthenticationException) {
+                return (AuthenticationException) current;
+            }
+            if (current instanceof NoHostAvailableException) {
+                for (Throwable hostError : ((NoHostAvailableException) current).getErrors().values()) {
+                    AuthenticationException found = authenticationFailure(hostError);
+                    if (found != null) {
+                        return found;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private Cluster authenticatedCluster() {
+        return Cluster.builder()
+                .addContactPoint(cassandraContainer.getHost())
+                .withPort(cassandraContainer.getMappedPort(CassandraContainer.CQL_PORT))
+                .withCredentials(SUPERUSER, SUPERUSER_PASSWORD)
+                .withoutJMXReporting()
+                .build();
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("roots", cassandraContainer.getHost() + ":"
+                + cassandraContainer.getMappedPort(CassandraContainer.CQL_PORT));
+        config.put("keyspace", KEYSPACE);
+        config.put("keyname", KEY_COLUMN);
+        config.put("columnFamily", TABLE);
+        config.put("columnName", VALUE_COLUMN);
+        return config;
+    }
+}

--- a/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthEnforcementTest.java
+++ b/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthEnforcementTest.java
@@ -138,6 +138,15 @@ public class CassandraSinkAuthEnforcementTest {
     }
 
     @Test
+    public void sinkFailsToOpenWithUnknownUser() {
+        Map<String, Object> config = baseConfig();
+        config.put("userName", "no-such-user");
+        config.put("password", SUPERUSER_PASSWORD);
+
+        assertOpenIsRejected(config);
+    }
+
+    @Test
     public void sinkWritesWhenCredentialsAreCorrect() throws Exception {
         Map<String, Object> config = baseConfig();
         config.put("userName", SUPERUSER);

--- a/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthTest.java
+++ b/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthTest.java
@@ -36,15 +36,19 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Covers the {@code userName} / {@code password} settings on {@link CassandraSinkConfig}.
+ * Covers the {@code userName} / {@code password} settings on {@link CassandraSinkConfig} against a
+ * cluster that does <em>not</em> require authentication — the image default,
+ * {@code AllowAllAuthenticator}.
  *
- * <p>Scope, stated plainly: these assert that credentials are carried through config loading and
- * that supplying them still yields a working connection and write. They do <em>not</em> assert that
- * the server rejects a connection without them — the Cassandra test container runs with the default
- * {@code AllowAllAuthenticator}, and switching it to {@code PasswordAuthenticator} needs a full
- * version-specific {@code cassandra.yaml} override. Enforcement is the server's behaviour; what is
- * this connector's to get right is that the credentials reach the driver, and that an unset pair
- * leaves the connection exactly as it was.
+ * <p>What that arrangement is good for is the compatibility half of these settings: credentials
+ * survive config loading, an unset pair is still unset, and neither supplying credentials nor
+ * omitting them stops the sink writing to a cluster that never asked for them. The last of those is
+ * the regression this connector most needs guarded — an existing unauthenticated deployment must be
+ * unaffected by the settings existing.
+ *
+ * <p>That a server actually refuses a connection without credentials, and that the configured pair
+ * is what gets past the refusal, is asserted in {@link CassandraSinkAuthEnforcementTest}, which runs
+ * a container with {@code PasswordAuthenticator} enabled.
  */
 public class CassandraSinkAuthTest {
 

--- a/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthTest.java
+++ b/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthTest.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.io.cassandra;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import java.time.Duration;
@@ -45,6 +47,9 @@ import org.testng.annotations.Test;
  * omitting them stops the sink writing to a cluster that never asked for them. The last of those is
  * the regression this connector most needs guarded — an existing unauthenticated deployment must be
  * unaffected by the settings existing.
+ *
+ * <p>It also covers the one case the connector rejects on its own account, without asking a server
+ * anything: a pair with only one half set.
  *
  * <p>That a server actually refuses a connection without credentials, and that the configured pair
  * is what gets past the refusal, is asserted in {@link CassandraSinkAuthEnforcementTest}, which runs
@@ -114,6 +119,46 @@ public class CassandraSinkAuthTest {
     @Test
     public void sinkWritesWithoutCredentials() throws Exception {
         assertWriteSucceeds(baseConfig(), "no-credentials");
+    }
+
+    @Test
+    public void openRejectsUsernameWithoutPassword() {
+        Map<String, Object> config = unroutableConfig();
+        config.put("userName", "cassandra");
+
+        assertHalfConfiguredPairRejected(config);
+    }
+
+    @Test
+    public void openRejectsPasswordWithoutUsername() {
+        Map<String, Object> config = unroutableConfig();
+        config.put("password", "cassandra");
+
+        assertHalfConfiguredPairRejected(config);
+    }
+
+    private void assertHalfConfiguredPairRejected(Map<String, Object> config) {
+        try {
+            new CassandraStringSink().open(config, mock(SinkContext.class));
+            fail("Expected open() to reject a credential pair with only one half set");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("userName and password must be supplied together"),
+                    "Rejected for some other reason: " + e.getMessage());
+        } catch (Exception e) {
+            fail("Expected IllegalArgumentException, got: " + e);
+        }
+    }
+
+    /**
+     * Config whose {@code roots} point at a port nothing listens on. The rejection above has to
+     * happen before any connection is attempted, and pointing somewhere unreachable is what makes
+     * the test say so: drop the validation and this fails connecting rather than passing for the
+     * wrong reason.
+     */
+    private Map<String, Object> unroutableConfig() {
+        Map<String, Object> config = baseConfig();
+        config.put("roots", "127.0.0.1:1");
+        return config;
     }
 
     private void assertWriteSucceeds(Map<String, Object> config, String key) throws Exception {

--- a/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthTest.java
+++ b/cassandra/src/test/java/org/apache/pulsar/io/cassandra/CassandraSinkAuthTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.cassandra;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SinkContext;
+import org.testcontainers.containers.CassandraContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Covers the {@code userName} / {@code password} settings on {@link CassandraSinkConfig}.
+ *
+ * <p>Scope, stated plainly: these assert that credentials are carried through config loading and
+ * that supplying them still yields a working connection and write. They do <em>not</em> assert that
+ * the server rejects a connection without them — the Cassandra test container runs with the default
+ * {@code AllowAllAuthenticator}, and switching it to {@code PasswordAuthenticator} needs a full
+ * version-specific {@code cassandra.yaml} override. Enforcement is the server's behaviour; what is
+ * this connector's to get right is that the credentials reach the driver, and that an unset pair
+ * leaves the connection exactly as it was.
+ */
+public class CassandraSinkAuthTest {
+
+    private static final String KEYSPACE = "auth_test_ks";
+    private static final String TABLE = "auth_test_table";
+    private static final String KEY_COLUMN = "key";
+    private static final String VALUE_COLUMN = "value";
+
+    private CassandraContainer<?> cassandraContainer;
+
+    @BeforeClass
+    public void setUp() {
+        cassandraContainer = new CassandraContainer<>("cassandra:4.1")
+                .withStartupTimeout(Duration.ofMinutes(3));
+        cassandraContainer.start();
+
+        try (Cluster cluster = cassandraContainer.getCluster();
+             Session session = cluster.connect()) {
+            session.execute("CREATE KEYSPACE " + KEYSPACE
+                    + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':'1'}");
+            session.execute("CREATE TABLE " + KEYSPACE + "." + TABLE
+                    + " (" + KEY_COLUMN + " text PRIMARY KEY, " + VALUE_COLUMN + " text)");
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown() {
+        if (cassandraContainer != null) {
+            cassandraContainer.stop();
+            cassandraContainer = null;
+        }
+    }
+
+    @Test
+    public void credentialsSurviveConfigLoading() throws Exception {
+        Map<String, Object> config = baseConfig();
+        config.put("userName", "cassandra");
+        config.put("password", "cassandra");
+
+        CassandraSinkConfig loaded = CassandraSinkConfig.load(config);
+
+        assertEquals(loaded.getUserName(), "cassandra");
+        assertEquals(loaded.getPassword(), "cassandra");
+    }
+
+    @Test
+    public void credentialsAreUnsetWhenNotConfigured() throws Exception {
+        CassandraSinkConfig loaded = CassandraSinkConfig.load(baseConfig());
+
+        assertNull(loaded.getUserName());
+        assertNull(loaded.getPassword());
+    }
+
+    @Test
+    public void sinkWritesWithCredentialsSupplied() throws Exception {
+        Map<String, Object> config = baseConfig();
+        config.put("userName", cassandraContainer.getUsername());
+        config.put("password", cassandraContainer.getPassword());
+
+        assertWriteSucceeds(config, "with-credentials");
+    }
+
+    @Test
+    public void sinkWritesWithoutCredentials() throws Exception {
+        assertWriteSucceeds(baseConfig(), "no-credentials");
+    }
+
+    private void assertWriteSucceeds(Map<String, Object> config, String key) throws Exception {
+        CassandraStringSink sink = new CassandraStringSink();
+        try {
+            sink.open(config, mock(SinkContext.class));
+
+            CompletableFuture<Void> acked = new CompletableFuture<>();
+            sink.write(new Record<byte[]>() {
+                @Override
+                public Optional<String> getKey() {
+                    return Optional.of(key);
+                }
+
+                @Override
+                public byte[] getValue() {
+                    return ("value-" + key).getBytes();
+                }
+
+                @Override
+                public void ack() {
+                    acked.complete(null);
+                }
+
+                @Override
+                public void fail() {
+                    acked.completeExceptionally(new RuntimeException("Record failed"));
+                }
+            });
+            acked.get();
+        } finally {
+            sink.close();
+        }
+
+        try (Cluster cluster = cassandraContainer.getCluster();
+             Session session = cluster.connect(KEYSPACE)) {
+            assertEquals(session
+                    .execute("SELECT * FROM " + TABLE + " WHERE " + KEY_COLUMN + " = '" + key + "'")
+                    .one()
+                    .getString(VALUE_COLUMN), "value-" + key);
+        }
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("roots", cassandraContainer.getHost() + ":" + cassandraContainer.getMappedPort(9042));
+        config.put("keyspace", KEYSPACE);
+        config.put("keyname", KEY_COLUMN);
+        config.put("columnFamily", TABLE);
+        config.put("columnName", VALUE_COLUMN);
+        return config;
+    }
+}


### PR DESCRIPTION
### Motivation

The Cassandra sink cannot connect to a cluster that requires authentication.
`CassandraSinkConfig` has no credential fields and `CassandraAbstractSink`
builds its `Cluster` with contact points only:

    Cluster.Builder b = Cluster.builder();
    ...
    cluster = b.withoutJMXReporting().build();

Any cluster running `PasswordAuthenticator` — which is the normal production
setting — is therefore unusable with this connector, with no workaround short
of forking it.

This gap was first reported in apache/pulsar#16179 (June 2022), which bundled
the fix with a larger schema-mapping feature. That PR could not be rebased
after PIP-465 moved the connectors out of the core repo, and the
authentication half stands on its own, so it is split out here.

### Modifications

- `CassandraSinkConfig` gains `userName` and `password`, both optional and
  `sensitive = true`. No existing field is changed.
- `CassandraAbstractSink.createClient` calls `withCredentials(...)` only when
  both are supplied, so an unset pair leaves the connection exactly as it was.
- `open()` rejects a pair with only one half set, alongside the existing
  required-property validation and so before any connection is attempted. Half a
  pair is never a meaningful configuration — whichever half is present, the intent
  was to authenticate — and connecting unauthenticated instead turns a typo into
  either a rejection from the server that names neither setting, or a silent
  success against a cluster that does not yet require authentication.
- `open()` loads config through `IOConfigUtils.loadWithSecrets` instead of
  `CassandraSinkConfig.load`, so the password can be supplied as a Pulsar
  secret rather than sitting in plaintext config. This is the same helper the
  kinesis, redis, canal and azure-data-explorer connectors already use. Fields
  with no secret configured still come from the config map; the pre-existing
  `CassandraStringSinkTest`, which opens the sink with a mocked `SinkContext`,
  passes unchanged and covers that.

The sink's write path, the `cassandra` connector registration and
`CassandraStringSink` are untouched.

### Verifying this change

`:cassandra:check` passes, twelve tests across two classes.

`CassandraSinkAuthTest` runs against an unauthenticated cluster — the image
default, `AllowAllAuthenticator` — and covers the compatibility half: credentials
survive config loading, they are null when unconfigured, and the sink writes
successfully both with and without them. That last case is the regression this
connector most needs guarded, since an existing unauthenticated deployment must be
unaffected by the settings existing, and it needs a server that does not ask for
credentials in order to mean anything.

`CassandraSinkAuthEnforcementTest` covers the other half against a cluster running
`PasswordAuthenticator`:

- `serverRejectsUnauthenticatedConnection` connects with the driver alone, no sink
  involved, and requires a refusal. Every other assertion in the class is only
  worth something while this one holds.
- `sinkFailsToOpenWithoutCredentials`, `sinkFailsToOpenWithWrongPassword` and
  `sinkFailsToOpenWithUnknownUser` require `open()` to be refused, unwrapping an
  `AuthenticationException` reported either directly or inside a
  `NoHostAvailableException`.
- `sinkWritesWhenCredentialsAreCorrect` requires the configured pair to get past
  that refusal and the row to land.

An earlier revision of this description said enforcement could not be asserted
without a full version-specific `cassandra.yaml` override. That is true only of the
container's `withConfigurationOverride()`, which volume-maps a whole directory over
`/etc/cassandra` and so requires carrying every file Cassandra reads from there.
Editing the shipped `cassandra.yaml` in place before the entrypoint runs does not,
and is what this does:

```java
.withCommand("sh", "-c",
    "sed -i 's/^authenticator:.*/authenticator: PasswordAuthenticator/' " + CONF
  + " && grep -q '^authenticator: PasswordAuthenticator' " + CONF
  + " && exec docker-entrypoint.sh cassandra -f")
```

The `grep` makes a substitution that matches nothing fatal — the container exits
rather than starting under `AllowAllAuthenticator` and leaving the assertions
vacuous. Cassandra 5 nests the setting under `authenticator.class_name`, so a later
image tag would otherwise gut the class silently.

`openRejectsUsernameWithoutPassword` and `openRejectsPasswordWithoutUsername` point
`roots` at a port nothing listens on, so they assert the rejection happens *before*
connecting rather than merely that it happens: with the validation removed they fail
with `NoHostAvailableException: ... Cannot connect` instead of passing for the wrong
reason.

Three mutation checks, since a passing test proves nothing on its own. With the
`withCredentials()` call deleted from `CassandraAbstractSink.createClient()`,
`sinkWritesWhenCredentialsAreCorrect` fails while `CassandraSinkAuthTest` stays
entirely green — that gap is precisely what the new class closes. Breaking the
`sed` pattern on purpose fails container startup rather than any assertion. The new
class ran clean five consecutive times; it costs one additional container.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

**The default values of configurations**: ticked for visibility. No existing
default changes — two new keys are added, both defaulting to unset, where unset
means exactly today's behaviour.

**Deployment**: the module gains `pulsar-io-common`, already in the version
catalog and used by several other connectors. Nothing changes for a deployment
that does not set the new keys.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

The new settings are described by their `@FieldDoc` help text.



